### PR TITLE
Add cmd/goversioninfo command-line app

### DIFF
--- a/cmd/goversioninfo/main.go
+++ b/cmd/goversioninfo/main.go
@@ -27,8 +27,25 @@ import (
 )
 
 func main() {
-	flagOut := flag.String("o", "resource.syso", "output file name")
 	flagExample := flag.Bool("example", false, "just dump out an example versioninfo.json to stdout")
+	flagOut := flag.String("o", "resource.syso", "output file name")
+
+	flagComment := flag.String("comment", "", "StringFileInfo.Comments")
+	flagCompany := flag.String("company", "", "StringFileInfo.CompanyName")
+	flagDescription := flag.String("description", "", "StringFileInfo.FileDescription")
+	flagFileVersion := flag.String("file-version", "", "StringFileInfo.FileVersion")
+	flagInternalName := flag.String("internal-name", "", "StringFileInfo.InternalName")
+	flagCopyright := flag.String("copyright", "", "StringFileInfo.LegalCopyright")
+	flagTrademark := flag.String("trademark", "", "StringFileInfo.LegalTrademarks")
+	flagOriginalName := flag.String("original-name", "", "StringFileInfo.OriginalFilename")
+	flagPrivateBuild := flag.String("private-build", "", "StringFileInfo.PrivateBuild")
+	flagProductName := flag.String("product-name", "", "StringFileInfo.ProductName")
+	flagProductVersion := flag.String("product-version", "", "StringFileInfo.ProductVersion")
+	flagSpecialBuild := flag.String("special-build", "", "StringFileInfo.SpecialBuild")
+
+	flagTranslation := flag.Int("translation", 0, "translation ID")
+	flagCharset := flag.Int("charset", 0, "charset ID")
+
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: %s [flags] <versioninfo.json>\n\nPossible flags:\n", os.Args[0])
 		flag.PrintDefaults()
@@ -68,6 +85,52 @@ func main() {
 		log.Printf("Could not parse the .json file: %v", err)
 		os.Exit(2)
 	}
+
+	// Override from flags
+	if *flagComment != "" {
+		vi.StringFileInfo.Comments = *flagComment
+	}
+	if *flagCompany != "" {
+		vi.StringFileInfo.CompanyName = *flagCompany
+	}
+	if *flagDescription != "" {
+		vi.StringFileInfo.FileDescription = *flagDescription
+	}
+	if *flagFileVersion != "" {
+		vi.StringFileInfo.FileVersion = *flagFileVersion
+	}
+	if *flagInternalName != "" {
+		vi.StringFileInfo.InternalName = *flagInternalName
+	}
+	if *flagCopyright != "" {
+		vi.StringFileInfo.LegalCopyright = *flagCopyright
+	}
+	if *flagTrademark != "" {
+		vi.StringFileInfo.LegalTrademarks = *flagTrademark
+	}
+	if *flagOriginalName != "" {
+		vi.StringFileInfo.OriginalFilename = *flagOriginalName
+	}
+	if *flagPrivateBuild != "" {
+		vi.StringFileInfo.PrivateBuild = *flagPrivateBuild
+	}
+	if *flagProductName != "" {
+		vi.StringFileInfo.ProductName = *flagProductName
+	}
+	if *flagProductVersion != "" {
+		vi.StringFileInfo.ProductVersion = *flagProductVersion
+	}
+	if *flagSpecialBuild != "" {
+		vi.StringFileInfo.SpecialBuild = *flagSpecialBuild
+	}
+
+	if *flagTranslation > 0 {
+		vi.VarFileInfo.Translation.LangID = goversioninfo.LangID(*flagTranslation)
+	}
+	if *flagCharset > 0 {
+		vi.VarFileInfo.Translation.CharsetID = goversioninfo.CharsetID(*flagCharset)
+	}
+
 	// Fill the structures with config data
 	vi.Build()
 

--- a/cmd/goversioninfo/main.go
+++ b/cmd/goversioninfo/main.go
@@ -1,0 +1,59 @@
+// Copyright 2015 Tamás Gulácsi
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"io/ioutil"
+	"log"
+	"os"
+
+	"github.com/josephspurrier/goversioninfo"
+)
+
+func main() {
+	flagOut := flag.String("o", "resource.syso", "output file name")
+	flag.Parse()
+
+	configFile := flag.Arg(0)
+	if configFile == "" {
+		configFile = "versioninfo.json"
+	}
+
+	// Read the config file
+	jsonBytes, err := ioutil.ReadFile(configFile)
+	if err != nil {
+		log.Printf("Error reading %q: %v", configFile, err)
+		os.Exit(1)
+	}
+
+	// Create a new container
+	vi := &goversioninfo.VersionInfo{}
+
+	// Parse the config
+	if err := vi.ParseJSON(jsonBytes); err != nil {
+		log.Printf("Could not parse the .json file: %v", err)
+		os.Exit(2)
+	}
+	// Fill the structures with config data
+	vi.Build()
+
+	// Write the data to a buffer
+	vi.Walk()
+
+	// Create the file
+	vi.WriteSyso(*flagOut)
+}

--- a/cmd/goversioninfo/main.go
+++ b/cmd/goversioninfo/main.go
@@ -46,6 +46,11 @@ func main() {
 	flagTranslation := flag.Int("translation", 0, "translation ID")
 	flagCharset := flag.Int("charset", 0, "charset ID")
 
+	flagVerMajor := flag.Int("ver-major", -1, "FileVersion.Major")
+	flagVerMinor := flag.Int("ver-minor", -1, "FileVersion.Minor")
+	flagVerPatch := flag.Int("ver-patch", -1, "FileVersion.Patch")
+	flagVerBuild := flag.Int("ver-build", -1, "FileVersion.Build")
+
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: %s [flags] <versioninfo.json>\n\nPossible flags:\n", os.Args[0])
 		flag.PrintDefaults()
@@ -129,6 +134,19 @@ func main() {
 	}
 	if *flagCharset > 0 {
 		vi.VarFileInfo.Translation.CharsetID = goversioninfo.CharsetID(*flagCharset)
+	}
+
+	if *flagVerMajor >= 0 {
+		vi.FixedFileInfo.FileVersion.Major = *flagVerMajor
+	}
+	if *flagVerMinor >= 0 {
+		vi.FixedFileInfo.FileVersion.Minor = *flagVerMinor
+	}
+	if *flagVerPatch >= 0 {
+		vi.FixedFileInfo.FileVersion.Patch = *flagVerPatch
+	}
+	if *flagVerBuild >= 0 {
+		vi.FixedFileInfo.FileVersion.Build = *flagVerBuild
 	}
 
 	// Fill the structures with config data

--- a/example_test.go
+++ b/example_test.go
@@ -2,13 +2,11 @@
 // Author: Joseph Spurrier (http://josephspurrier.com)
 // License: http://www.apache.org/licenses/LICENSE-2.0.html
 
-package goversioninfo_test
+package goversioninfo
 
 import (
 	"fmt"
 	"io/ioutil"
-
-	"github.com/josephspurrier/goversioninfo"
 )
 
 // Example
@@ -26,7 +24,7 @@ func logic() {
 	}
 
 	// Create a new container
-	vi := &goversioninfo.VersionInfo{}
+	vi := &VersionInfo{}
 
 	// Parse the config
 	if err := vi.ParseJSON(jsonBytes); err != nil {

--- a/example_test.go
+++ b/example_test.go
@@ -6,8 +6,9 @@ package goversioninfo_test
 
 import (
 	"fmt"
-	"github.com/josephspurrier/goversioninfo"
 	"io/ioutil"
+
+	"github.com/josephspurrier/goversioninfo"
 )
 
 // Example
@@ -28,16 +29,17 @@ func logic() {
 	vi := &goversioninfo.VersionInfo{}
 
 	// Parse the config
-	if ok := vi.ParseJSON(jsonBytes); ok {
-		// Fill the structures with config data
-		vi.Build()
-
-		// Write the data to a buffer
-		vi.Walk()
-
-		// Create the file
-		vi.WriteSyso("resource.syso")
-	} else {
+	if err := vi.ParseJSON(jsonBytes); err != nil {
 		fmt.Println("Could not parse the .json file")
+	}
+	// Fill the structures with config data
+	vi.Build()
+
+	// Write the data to a buffer
+	vi.Walk()
+
+	// Create the file
+	if err := vi.WriteSyso("resource.syso"); err != nil {
+		fmt.Println("Could not write resource.syso: %v", err)
 	}
 }

--- a/example_test.go
+++ b/example_test.go
@@ -40,6 +40,6 @@ func logic() {
 
 	// Create the file
 	if err := vi.WriteSyso("resource.syso"); err != nil {
-		fmt.Println("Could not write resource.syso: %v", err)
+		fmt.Printf("Could not write resource.syso: %v", err)
 	}
 }

--- a/goversioninfo.go
+++ b/goversioninfo.go
@@ -9,8 +9,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"log"
+	"os"
 	"reflect"
 	"strconv"
 
@@ -214,117 +216,37 @@ func (vi *VersionInfo) WriteHex(filename string) error {
 	return ioutil.WriteFile(filename, vi.Buffer.Bytes(), 0655)
 }
 
-type CharsetID uint16
-
-const (
-	Cs7ASCII       = CharsetID(0)    // Cs7ASCII:	0	0000	7-bit ASCII
-	CsJIS          = CharsetID(932)  // CsJIS:	932	03A4	Japan (Shift ? JIS X-0208)
-	CsKSC          = CharsetID(949)  // CsKSC:	949	03B5	Korea (Shift ? KSC 5601)
-	CsBig5         = CharsetID(950)  // CsBig5:	950	03B6	Taiwan (Big5)
-	CsUnicode      = CharsetID(1200) // CsUnicode:	1200	04B0	Unicode
-	CsLatin2       = CharsetID(1250) // CsLatin2:	1250	04E2	Latin-2 (Eastern European)
-	CsCyrillic     = CharsetID(1251) // CsCyrillic:	1251	04E3	Cyrillic
-	CsMultilingual = CharsetID(1252) // CsMultilingual:	1252	04E4	Multilingual
-	CsGreek        = CharsetID(1253) // CsGreek:	1253	04E5	Greek
-	CsTurkish      = CharsetID(1254) // CsTurkish:	1254	04E6	Turkish
-	CsHebrew       = CharsetID(1255) // CsHebrew:	1255	04E7	Hebrew
-	CsArabic       = CharsetID(1256) // CsArabic:	1256	04E8	Arabic
-)
-
-func (cs *CharsetID) UnmarshalJSON(p []byte) error {
-	if len(p) == 0 {
-		return nil
-	}
-	if p[0] != '"' {
-		var u uint16
-		if err := json.Unmarshal(p, &u); err != nil {
-			return err
-		}
-		*cs = CharsetID(u)
-		return nil
-	}
-	var s string
-	if err := json.Unmarshal(p, &s); err != nil {
-		return err
-	}
-	u, err := strconv.ParseUint(s, 16, 16)
+func writeCoff(coff *coff.Coff, fnameout string) error {
+	out, err := os.Create(fnameout)
 	if err != nil {
 		return err
 	}
-	*cs = CharsetID(u)
+	if err = writeCoffTo(out, coff); err != nil {
+		return fmt.Errorf("error writing %q: %v", fnameout, err)
+	}
 	return nil
 }
 
-type LangID uint16
+func writeCoffTo(w io.WriteCloser, coff *coff.Coff) error {
+	bw := binutil.Writer{W: w}
 
-func (lng *LangID) UnmarshalJSON(p []byte) error {
-	if len(p) == 0 {
-		return nil
-	}
-	if p[0] != '"' {
-		var u uint16
-		if err := json.Unmarshal(p, &u); err != nil {
-			return err
+	// write the resulting file to disk
+	binutil.Walk(coff, func(v reflect.Value, path string) error {
+		if binutil.Plain(v.Kind()) {
+			bw.WriteLE(v.Interface())
+			return nil
 		}
-		*lng = LangID(u)
+		vv, ok := v.Interface().(binutil.SizedReader)
+		if ok {
+			bw.WriteFromSized(vv)
+			return binutil.WALK_SKIP
+		}
 		return nil
-	}
-	var s string
-	if err := json.Unmarshal(p, &s); err != nil {
-		return err
-	}
-	u, err := strconv.ParseUint(s, 16, 16)
-	if err != nil {
-		return err
-	}
-	*lng = LangID(u)
-	return nil
-}
+	})
 
-const (
-	LngArabic                = LangID(0x0401) // LngArabic: 0x0401 Arabic
-	LngBulgarian             = LangID(0x0402) // LngBulgarian: 0x0402 Bulgarian
-	LngCatalan               = LangID(0x0403) // LngCatalan: 0x0403 Catalan
-	LngTraditionalChinese    = LangID(0x0404) // LngTraditionalChinese: 0x0404 Traditional Chinese
-	LngCzech                 = LangID(0x0405) // LngCzech: 0x0405 Czech
-	LngDanish                = LangID(0x0406) // LngDanish: 0x0406 Danish
-	LngGerman                = LangID(0x0407) // LngGerman: 0x0407 German
-	LngGreek                 = LangID(0x0408) // LngGreek: 0x0408 Greek
-	LngUSEnglish             = LangID(0x0409) // LngUSEnglish: 0x0409 U.S. English
-	LngCastilianSpanish      = LangID(0x040A) // LngCastilianSpanish: 0x040A Castilian Spanish
-	LngFinnish               = LangID(0x040B) // LngFinnish: 0x040B Finnish
-	LngFrench                = LangID(0x040C) // LngFrench: 0x040C French
-	LngHebrew                = LangID(0x040D) // LngHebrew: 0x040D Hebrew
-	LngHungarian             = LangID(0x040E) // LngHungarian: 0x040E Hungarian
-	LngIcelandic             = LangID(0x040F) // LngIcelandic: 0x040F Icelandic
-	LngItalian               = LangID(0x0410) // LngItalian: 0x0410 Italian
-	LngJapanese              = LangID(0x0411) // LngJapanese: 0x0411 Japanese
-	LngKorean                = LangID(0x0412) // LngKorean: 0x0412 Korean
-	LngDutch                 = LangID(0x0413) // LngDutch: 0x0413 Dutch
-	LngNorwegianBokmal       = LangID(0x0414) // LngNorwegianBokmal: 0x0414 Norwegian ? Bokmal
-	LngPolish                = LangID(0x0415) // LngPolish: 0x0415 Polish
-	LngPortugueseBrazil      = LangID(0x0416) // LngPortugueseBrazil: 0x0416 Portuguese (Brazil)
-	LngRhaetoRomanic         = LangID(0x0417) // LngRhaetoRomanic: 0x0417 Rhaeto-Romanic
-	LngRomanian              = LangID(0x0418) // LngRomanian: 0x0418 Romanian
-	LngRussian               = LangID(0x0419) // LngRussian: 0x0419 Russian
-	LngCroatoSerbianLatin    = LangID(0x041A) // LngCroatoSerbianLatin: 0x041A Croato-Serbian (Latin)
-	LngSlovak                = LangID(0x041B) // LngSlovak: 0x041B Slovak
-	LngAlbanian              = LangID(0x041C) // LngAlbanian: 0x041C Albanian
-	LngSwedish               = LangID(0x041D) // LngSwedish: 0x041D Swedish
-	LngThai                  = LangID(0x041E) // LngThai: 0x041E Thai
-	LngTurkish               = LangID(0x041F) // LngTurkish: 0x041F Turkish
-	LngUrdu                  = LangID(0x0420) // LngUrdu: 0x0420 Urdu
-	LngBahasa                = LangID(0x0421) // LngBahasa: 0x0421 Bahasa
-	LngSimplifiedChinese     = LangID(0x0804) // LngSimplifiedChinese: 0x0804 Simplified Chinese
-	LngSwissGerman           = LangID(0x0807) // LngSwiss German: 0x0807 Swiss German
-	LngUKEnglish             = LangID(0x0809) // LngUKEnglish: 0x0809 U.K. English
-	LngSpanishMexico         = LangID(0x080A) // LngSpanishMexico: 0x080A Spanish (Mexico)
-	LngBelgianFrench         = LangID(0x080C) // LngBelgian French: 0x080C Belgian French
-	LngSwissItalian          = LangID(0x0810) // LngSwiss Italian: 0x0810 Swiss Italian
-	LngBelgianDutch          = LangID(0x0813) // LngBelgian Dutch: 0x0813 Belgian Dutch
-	LngNorwegianNynorsk      = LangID(0x0814) // LngNorwegianNynorsk: 0x0814 Norwegian ? Nynorsk
-	LngPortuguesePortugal    = LangID(0x0816) // LngPortuguese (Portugal): 0x0816 Portuguese (Portugal)
-	LngSerboCroatianCyrillic = LangID(0x081A) // LngSerboCroatianCyrillic: 0x081A Serbo-Croatian (Cyrillic)
-	LngCanadianFrench        = LangID(0x0C0C) // LngCanadian French: 0x0C0C Canadian French
-	LngSwissFrench           = LangID(0x100C) // LngSwiss French: 0x100C Swiss French
-)
+	err := bw.Err
+	if closeErr := w.Close(); closeErr != nil && err == nil {
+		err = closeErr
+	}
+	return err
+}

--- a/goversioninfo.go
+++ b/goversioninfo.go
@@ -2,38 +2,31 @@
 // Author: Joseph Spurrier (http://josephspurrier.com)
 // License: http://www.apache.org/licenses/LICENSE-2.0.html
 
-// Package goversion create syso files with Microsoft Version Information embedded.
+// Package goversioninfo create syso files with Microsoft Version Information embedded.
 package goversioninfo
 
 import (
 	"bytes"
-	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	"io"
 	"io/ioutil"
-	"math"
-	"os"
 	"reflect"
 	"strconv"
-	//"syscall"
-	//"time"
 
 	"github.com/akavel/rsrc/binutil"
 	"github.com/akavel/rsrc/coff"
-	"github.com/akavel/rsrc/ico"
 )
 
 // *****************************************************************************
 // JSON and Config
 // *****************************************************************************
 
-// Parse JSON file to structs
+// ParseJSON parses the given bytes as a VersionInfo JSON.
 func (vi *VersionInfo) ParseJSON(jsonBytes []byte) error {
 	return json.Unmarshal([]byte(jsonBytes), &vi)
 }
 
-// Version Info data container
+// VersionInfo data container
 type VersionInfo struct {
 	FixedFileInfo  `json:"FixedFileInfo"`
 	StringFileInfo `json:"StringFileInfo"`
@@ -45,13 +38,13 @@ type VersionInfo struct {
 	IconPath       string
 }
 
-// Translation with langid and charsetid
+// Translation with langid and charsetid.
 type Translation struct {
 	LangID    string
 	CharsetID string
 }
 
-// Version with 3 parts
+// FileVersion with 3 parts.
 type FileVersion struct {
 	Major int
 	Minor int
@@ -59,7 +52,7 @@ type FileVersion struct {
 	Build int
 }
 
-// File characteristics - leave most of them at the defaults
+// FixedFileInfo contains file characteristics - leave most of them at the defaults.
 type FixedFileInfo struct {
 	FileVersion    `json:"FileVersion"`
 	ProductVersion FileVersion
@@ -70,12 +63,12 @@ type FixedFileInfo struct {
 	FileSubType    string
 }
 
-// Translation container
+// VarFileInfo is the translation container.
 type VarFileInfo struct {
 	Translation `json:"Translation"`
 }
 
-// Settings you want to change
+// StringFileInfo is what you want to change.
 type StringFileInfo struct {
 	Comments         string
 	CompanyName      string
@@ -116,7 +109,7 @@ func str2Uint32(s string) uint32 {
 }
 
 func buildUnicode(s string, zeroTerminate bool) []byte {
-	b := make([]byte, 0)
+	b := make([]byte, 0, len(s)*2+2)
 
 	for _, x := range s {
 		b = append(b, byte(x))
@@ -161,13 +154,13 @@ func (t Translation) getTranslation() string {
 // *****************************************************************************
 
 // Walk fills the data buffer with hexidecimal data from the structs
-func (v *VersionInfo) Walk() {
+func (vi *VersionInfo) Walk() {
 	// Create a buffer
 	var b bytes.Buffer
 	w := binutil.Writer{W: &b}
 
 	// Write to the buffer
-	binutil.Walk(v.Structure, func(v reflect.Value, path string) error {
+	binutil.Walk(vi.Structure, func(v reflect.Value, path string) error {
 		if binutil.Plain(v.Kind()) {
 			w.WriteLE(v.Interface())
 			return nil
@@ -180,30 +173,30 @@ func (v *VersionInfo) Walk() {
 		return nil
 	})
 
-	v.Buffer = b
+	vi.Buffer = b
 }
 
 // WriteSyso creates a resource file from the version info and optionally an icon
-func (v *VersionInfo) WriteSyso(filename string) error {
+func (vi *VersionInfo) WriteSyso(filename string) error {
 
 	// Channel for generating IDs
-	newid := make(chan uint16)
+	newID := make(chan uint16)
 	go func() {
 		for i := uint16(1); ; i++ {
-			newid <- i
+			newID <- i
 		}
 	}()
 
 	// Create a new RSRC section
 	coff := coff.NewRSRC()
-	//id := <-newid
+	//id := <-newID
 
 	// ID 16 is for Version Information
-	coff.AddResource(16, 1, sizedReader{&v.Buffer})
+	coff.AddResource(16, 1, sizedReader{&vi.Buffer})
 
 	// If icon is enabled
-	if v.Icon {
-		if err := addicon(coff, v.IconPath, newid); err != nil {
+	if vi.Icon {
+		if err := addIcon(coff, vi.IconPath, newID); err != nil {
 			return err
 		}
 	}
@@ -215,419 +208,6 @@ func (v *VersionInfo) WriteSyso(filename string) error {
 }
 
 // WriteHex creates a hex file for debugging version info
-func (v *VersionInfo) WriteHex(filename string) error {
-	return ioutil.WriteFile(filename, v.Buffer.Bytes(), 0655)
-}
-
-// *****************************************************************************
-// Structure Building
-// *****************************************************************************
-
-/*
-Version Information Structures
-http://msdn.microsoft.com/en-us/library/windows/desktop/ff468916.aspx
-
-VersionInfo Names
-http://msdn.microsoft.com/en-us/library/windows/desktop/aa381058.aspx#string-name
-
-Translation: LangID
-http://msdn.microsoft.com/en-us/library/windows/desktop/aa381058.aspx#langid
-
-Translation: CharsetID
-http://msdn.microsoft.com/en-us/library/windows/desktop/aa381058.aspx#charsetid
-
-*/
-
-// Top level version container
-type VS_VersionInfo struct {
-	WLength      uint16
-	WValueLength uint16
-	WType        uint16
-	SzKey        []byte
-	Padding1     []byte
-	Value        VS_FixedFileInfo
-	Padding2     []byte
-	Children     VS_StringFileInfo
-	Children2    VS_VarFileInfo
-}
-
-// Most of these should be left at the defaults
-type VS_FixedFileInfo struct {
-	DwSignature        uint32
-	DwStrucVersion     uint32
-	DwFileVersionMS    uint32
-	DwFileVersionLS    uint32
-	DwProductVersionMS uint32
-	DwProductVersionLS uint32
-	DwFileFlagsMask    uint32
-	DwFileFlags        uint32
-	DwFileOS           uint32
-	DwFileType         uint32
-	DwFileSubtype      uint32
-	DwFileDateMS       uint32
-	DwFileDateLS       uint32
-}
-
-// Holds multiple collections of keys and values, only allows for 1 collection in
-// this package
-type VS_StringFileInfo struct {
-	WLength      uint16
-	WValueLength uint16
-	WType        uint16
-	SzKey        []byte
-	Padding      []byte
-	Children     VS_StringTable
-}
-
-// Holds a collection of string keys and values
-type VS_StringTable struct {
-	WLength      uint16
-	WValueLength uint16
-	WType        uint16
-	SzKey        []byte
-	Padding      []byte
-	Children     []VS_String
-}
-
-// Holds the keys and values
-type VS_String struct {
-	WLength      uint16
-	WValueLength uint16
-	WType        uint16
-	SzKey        []byte
-	Padding1     []byte
-	Value        []byte
-	Padding2     []byte
-}
-
-// Holds the translation collection of 1
-type VS_VarFileInfo struct {
-	WLength      uint16
-	WValueLength uint16
-	WType        uint16
-	SzKey        []byte
-	Padding      []byte
-	Value        VS_Var
-}
-
-// Holds the translation key
-type VS_Var struct {
-	WLength      uint16
-	WValueLength uint16
-	WType        uint16
-	SzKey        []byte
-	Padding      []byte
-	Value        uint32
-}
-
-func buildString(i int, v reflect.Value) (VS_String, bool, uint16) {
-	sValue := string(v.Field(i).Interface().(string))
-	sName := v.Type().Field(i).Name
-
-	ss := VS_String{}
-
-	// If the value is set
-	if sValue != "" {
-		// Create key
-		ss.SzKey = buildUnicode(sName, false)
-		soFar := len(ss.SzKey) + 6
-		ss.Padding1 = padBytes(4 - int(math.Mod(float64(soFar), 4)))
-		// Ensure there is at least 4 bytes between the key and value by NOT
-		// using this code
-		/*if len(ss.Padding1) == 4 {
-			ss.Padding1 = []byte{}
-		}*/
-
-		// Create value
-		ss.Value = buildUnicode(sValue, true)
-		soFar += (len(ss.Value) + len(ss.Padding1))
-		ss.Padding2 = padBytes(4 - int(math.Mod(float64(soFar), 4)))
-		// Eliminate too much spacing
-		if len(ss.Padding2) == 4 {
-			ss.Padding2 = []byte{}
-		}
-
-		// Length of text in words (2 bytes)
-		ss.WValueLength = uint16(len(ss.Value) / 2)
-		// This is NOT a good way because the copyright symbol counts as 2 letters
-		//ss.WValueLength = uint16(len(sValue) + 1)
-
-		// 0 for binary, 1 for text
-		ss.WType = 0x01
-
-		// Length of structure
-		ss.WLength = uint16(soFar)
-		// Don't include the padding in the length, but you must pass it back to
-		// the parent to be included
-		//ss.WLength = uint16(soFar + len(ss.Padding2))
-
-		return ss, true, uint16(len(ss.Padding2))
-	}
-
-	return ss, false, 0
-}
-
-func buildStringTable(vi *VersionInfo) (VS_StringTable, uint16) {
-	st := VS_StringTable{}
-
-	// Always set to 0
-	st.WValueLength = 0x00
-
-	// 0 for binary, 1 for text
-	st.WType = 0x01
-
-	// Language identifier and Code page
-	st.SzKey = buildUnicode(vi.VarFileInfo.Translation.getTranslationString(), false)
-	soFar := len(st.SzKey) + 6
-	st.Padding = padBytes(4 - int(math.Mod(float64(soFar), 4)))
-
-	// Loop through the struct fields
-	v := reflect.ValueOf(vi.StringFileInfo)
-	for i := 0; i < v.NumField(); i++ {
-		// If the struct is valid
-		if r, ok, extra := buildString(i, v); ok {
-			st.Children = append(st.Children, r)
-			st.WLength += (r.WLength + extra)
-		}
-	}
-
-	st.WLength += uint16(soFar)
-
-	return st, uint16(len(st.Padding))
-}
-
-func buildStringFileInfo(vi *VersionInfo) (VS_StringFileInfo, uint16) {
-	sf := VS_StringFileInfo{}
-
-	// Always set to 0
-	sf.WValueLength = 0x00
-
-	// 0 for binary, 1 for text
-	sf.WType = 0x01
-
-	sf.SzKey = buildUnicode("StringFileInfo", false)
-	soFar := len(sf.SzKey) + 6
-	sf.Padding = padBytes(4 - int(math.Mod(float64(soFar), 4)))
-
-	// Allows for more than one string table
-	st, extra := buildStringTable(vi)
-	sf.Children = st
-	sf.WLength += (uint16(soFar) + uint16(len(sf.Padding)) + st.WLength)
-
-	return sf, extra
-}
-
-func buildVar(vfi VarFileInfo) VS_Var {
-	vs := VS_Var{}
-	// Create key
-	vs.SzKey = buildUnicode("Translation", false)
-	soFar := len(vs.SzKey) + 6
-	vs.Padding = padBytes(4 - int(math.Mod(float64(soFar), 4)))
-
-	// Create value
-	vs.Value = str2Uint32(vfi.Translation.getTranslation())
-	soFar += (4 + len(vs.Padding))
-
-	// Length of text in bytes
-	vs.WValueLength = 4
-
-	// 0 for binary, 1 for text
-	vs.WType = 0x00
-
-	// Length of structure
-	vs.WLength = uint16(soFar)
-
-	return vs
-}
-
-func buildVarFileInfo(vfi VarFileInfo) VS_VarFileInfo {
-	vf := VS_VarFileInfo{}
-
-	// Always set to 0
-	vf.WValueLength = 0x00
-
-	// 0 for binary, 1 for text
-	vf.WType = 0x01
-
-	vf.SzKey = buildUnicode("VarFileInfo", false)
-	soFar := len(vf.SzKey) + 6
-	vf.Padding = padBytes(4 - int(math.Mod(float64(soFar), 4)))
-
-	// Allows for more than one string table
-	st := buildVar(vfi)
-	vf.Value = st
-	vf.WLength += (uint16(soFar) + uint16(len(vf.Padding)) + st.WLength)
-
-	return vf
-}
-
-func buildFixedFileInfo(vi *VersionInfo) VS_FixedFileInfo {
-	ff := VS_FixedFileInfo{}
-	ff.DwSignature = 0xFEEF04BD
-	ff.DwStrucVersion = 0x00010000
-	ff.DwFileVersionMS = str2Uint32(vi.FixedFileInfo.FileVersion.getVersionHighString())
-	ff.DwFileVersionLS = str2Uint32(vi.FixedFileInfo.FileVersion.getVersionLowString())
-	ff.DwProductVersionMS = str2Uint32(vi.FixedFileInfo.ProductVersion.getVersionHighString())
-	ff.DwProductVersionLS = str2Uint32(vi.FixedFileInfo.ProductVersion.getVersionLowString())
-	ff.DwFileFlagsMask = str2Uint32(vi.FixedFileInfo.FileFlagsMask)
-	ff.DwFileFlags = str2Uint32(vi.FixedFileInfo.FileFlags)
-	ff.DwFileOS = str2Uint32(vi.FixedFileInfo.FileOS)
-	ff.DwFileType = str2Uint32(vi.FixedFileInfo.FileType)
-	ff.DwFileSubtype = str2Uint32(vi.FixedFileInfo.FileSubType)
-
-	// According to the spec, these should be zero...ugh
-	/*if vi.Timestamp {
-		now := syscall.NsecToFiletime(time.Now().UnixNano())
-		ff.DwFileDateMS = now.HighDateTime
-		ff.DwFileDateLS = now.LowDateTime
-	}*/
-
-	return ff
-}
-
-// Build fills the structs with data from the config file
-func (v *VersionInfo) Build() {
-	vi := VS_VersionInfo{}
-
-	// 0 for binary, 1 for text
-	vi.WType = 0x00
-
-	vi.SzKey = buildUnicode("VS_VERSION_INFO", false)
-	soFar := len(vi.SzKey) + 6
-	vi.Padding1 = padBytes(4 - int(math.Mod(float64(soFar), 4)))
-
-	vi.Value = buildFixedFileInfo(v)
-
-	// Length of value (always the same)
-	vi.WValueLength = 0x34
-
-	// Never needs padding
-	vi.Padding2 = []byte{}
-
-	// Build strings
-	sf, extraPadding := buildStringFileInfo(v)
-	vi.Children = sf
-
-	// Build translation
-	vf := buildVarFileInfo(v.VarFileInfo)
-	vi.Children2 = vf
-
-	// Calculate the total size
-	vi.WLength += (uint16(soFar) + uint16(len(vi.Padding1)) + vi.WValueLength + uint16(len(vi.Padding2)) + vi.Children.WLength + vi.Children2.WLength + extraPadding)
-
-	v.Structure = vi
-}
-
-// *****************************************************************************
-/*
-Code from https://github.com/akavel/rsrc
-
-The MIT License (MIT)
-
-Copyright (c) 2013-2014 The rsrc Authors.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-*/
-// *****************************************************************************
-
-const (
-	rt_ICON       = coff.RT_ICON
-	rt_GROUP_ICON = coff.RT_GROUP_ICON
-)
-
-// on storing icons, see: http://blogs.msdn.com/b/oldnewthing/archive/2012/07/20/10331787.aspx
-type gRPICONDIR struct {
-	ico.ICONDIR
-	Entries []gRPICONDIRENTRY
-}
-
-func (group gRPICONDIR) Size() int64 {
-	return int64(binary.Size(group.ICONDIR) + len(group.Entries)*binary.Size(group.Entries[0]))
-}
-
-type gRPICONDIRENTRY struct {
-	ico.IconDirEntryCommon
-	Id uint16
-}
-
-func addicon(coff *coff.Coff, fname string, newid <-chan uint16) error {
-	f, err := os.Open(fname)
-	if err != nil {
-		return err
-	}
-	//defer f.Close() don't defer, files will be closed by OS when app closes
-
-	icons, err := ico.DecodeHeaders(f)
-	if err != nil {
-		return err
-	}
-
-	if len(icons) > 0 {
-		// RT_ICONs
-		group := gRPICONDIR{ICONDIR: ico.ICONDIR{
-			Reserved: 0, // magic num.
-			Type:     1, // magic num.
-			Count:    uint16(len(icons)),
-		}}
-		for _, icon := range icons {
-			id := <-newid
-			r := io.NewSectionReader(f, int64(icon.ImageOffset), int64(icon.BytesInRes))
-			coff.AddResource(rt_ICON, id, r)
-			group.Entries = append(group.Entries, gRPICONDIRENTRY{icon.IconDirEntryCommon, id})
-		}
-		id := <-newid
-		coff.AddResource(rt_GROUP_ICON, id, group)
-	}
-
-	return nil
-}
-
-func writeCoff(coff *coff.Coff, fnameout string) error {
-	out, err := os.Create(fnameout)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		// close error is important
-		if closeErr := out.Close(); closeErr != nil && err == nil {
-			err = closeErr
-		}
-	}()
-	w := binutil.Writer{W: out}
-
-	// write the resulting file to disk
-	binutil.Walk(coff, func(v reflect.Value, path string) error {
-		if binutil.Plain(v.Kind()) {
-			w.WriteLE(v.Interface())
-			return nil
-		}
-		vv, ok := v.Interface().(binutil.SizedReader)
-		if ok {
-			w.WriteFromSized(vv)
-			return binutil.WALK_SKIP
-		}
-		return nil
-	})
-
-	if err = w.Err; err != nil {
-		return fmt.Errorf("Error writing %q file: %v", fnameout, w.Err)
-	}
-
-	return nil
+func (vi *VersionInfo) WriteHex(filename string) error {
+	return ioutil.WriteFile(filename, vi.Buffer.Bytes(), 0655)
 }

--- a/goversioninfo.go
+++ b/goversioninfo.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"reflect"
 	"strconv"
 
@@ -97,11 +98,12 @@ func (s sizedReader) Size() int64 {
 }
 
 func str2Uint32(s string) uint32 {
-	u, err := strconv.ParseUint(s, 16, 32)
 	if s == "" {
 		return 0
-	} else if err != nil {
-		fmt.Println("Error parsing uint32:", s, err)
+	}
+	u, err := strconv.ParseUint(s, 16, 32)
+	if err != nil {
+		log.Printf("Error parsing %q as uint32: %v", s, err)
 		return 0
 	}
 
@@ -215,35 +217,31 @@ func (vi *VersionInfo) WriteHex(filename string) error {
 type CharsetID uint16
 
 const (
-	// Cs7ASCII:	0	0000	7-bit ASCII
-	Cs7ASCII = CharsetID(0)
-	// CsJIS:	932	03A4	Japan (Shift ? JIS X-0208)
-	CsJIS = CharsetID(932)
-	// CsKSC:	949	03B5	Korea (Shift ? KSC 5601)
-	CsKSC = CharsetID(949)
-	// CsBig5:	950	03B6	Taiwan (Big5)
-	CsBig5 = CharsetID(950)
-	// CsUnicode:	1200	04B0	Unicode
-	CsUnicode = CharsetID(1200)
-	// CsLatin2:	1250	04E2	Latin-2 (Eastern European)
-	CsLatin2 = CharsetID(1250)
-	// CsCyrillic:	1251	04E3	Cyrillic
-	CsCyrillic = CharsetID(1251)
-	// CsMultilingual:	1252	04E4	Multilingual
-	CsMultilingual = CharsetID(1252)
-	// CsGreek:	1253	04E5	Greek
-	CsGreek = CharsetID(1253)
-	// CsTurkish:	1254	04E6	Turkish
-	CsTurkish = CharsetID(1254)
-	// CsHebrew:	1255	04E7	Hebrew
-	CsHebrew = CharsetID(1255)
-	// CsArabic:	1256	04E8	Arabic
-	CsArabic = CharsetID(1256)
+	Cs7ASCII       = CharsetID(0)    // Cs7ASCII:	0	0000	7-bit ASCII
+	CsJIS          = CharsetID(932)  // CsJIS:	932	03A4	Japan (Shift ? JIS X-0208)
+	CsKSC          = CharsetID(949)  // CsKSC:	949	03B5	Korea (Shift ? KSC 5601)
+	CsBig5         = CharsetID(950)  // CsBig5:	950	03B6	Taiwan (Big5)
+	CsUnicode      = CharsetID(1200) // CsUnicode:	1200	04B0	Unicode
+	CsLatin2       = CharsetID(1250) // CsLatin2:	1250	04E2	Latin-2 (Eastern European)
+	CsCyrillic     = CharsetID(1251) // CsCyrillic:	1251	04E3	Cyrillic
+	CsMultilingual = CharsetID(1252) // CsMultilingual:	1252	04E4	Multilingual
+	CsGreek        = CharsetID(1253) // CsGreek:	1253	04E5	Greek
+	CsTurkish      = CharsetID(1254) // CsTurkish:	1254	04E6	Turkish
+	CsHebrew       = CharsetID(1255) // CsHebrew:	1255	04E7	Hebrew
+	CsArabic       = CharsetID(1256) // CsArabic:	1256	04E8	Arabic
 )
 
 func (cs *CharsetID) UnmarshalJSON(p []byte) error {
+	if len(p) == 0 {
+		return nil
+	}
 	if p[0] != '"' {
-		return json.Unmarshal(p, cs)
+		var u uint16
+		if err := json.Unmarshal(p, &u); err != nil {
+			return err
+		}
+		*cs = CharsetID(u)
+		return nil
 	}
 	var s string
 	if err := json.Unmarshal(p, &s); err != nil {
@@ -260,8 +258,16 @@ func (cs *CharsetID) UnmarshalJSON(p []byte) error {
 type LangID uint16
 
 func (lng *LangID) UnmarshalJSON(p []byte) error {
+	if len(p) == 0 {
+		return nil
+	}
 	if p[0] != '"' {
-		return json.Unmarshal(p, lng)
+		var u uint16
+		if err := json.Unmarshal(p, &u); err != nil {
+			return err
+		}
+		*lng = LangID(u)
+		return nil
 	}
 	var s string
 	if err := json.Unmarshal(p, &s); err != nil {

--- a/goversioninfo.go
+++ b/goversioninfo.go
@@ -40,8 +40,8 @@ type VersionInfo struct {
 
 // Translation with langid and charsetid.
 type Translation struct {
-	LangID    string
-	CharsetID string
+	LangID    LangID
+	CharsetID CharsetID
 }
 
 // FileVersion with 3 parts.
@@ -142,11 +142,11 @@ func (f FileVersion) GetVersionString() string {
 }
 
 func (t Translation) getTranslationString() string {
-	return fmt.Sprintf("%04X%04X", str2Uint32(t.LangID), str2Uint32(t.CharsetID))
+	return fmt.Sprintf("%04X%04X", t.LangID, t.CharsetID)
 }
 
 func (t Translation) getTranslation() string {
-	return fmt.Sprintf("%04x%04x", str2Uint32(t.CharsetID), str2Uint32(t.LangID))
+	return fmt.Sprintf("%04x%04x", t.CharsetID, t.LangID)
 }
 
 // *****************************************************************************
@@ -211,3 +211,114 @@ func (vi *VersionInfo) WriteSyso(filename string) error {
 func (vi *VersionInfo) WriteHex(filename string) error {
 	return ioutil.WriteFile(filename, vi.Buffer.Bytes(), 0655)
 }
+
+type CharsetID uint16
+
+const (
+	// Cs7ASCII:	0	0000	7-bit ASCII
+	Cs7ASCII = CharsetID(0)
+	// CsJIS:	932	03A4	Japan (Shift ? JIS X-0208)
+	CsJIS = CharsetID(932)
+	// CsKSC:	949	03B5	Korea (Shift ? KSC 5601)
+	CsKSC = CharsetID(949)
+	// CsBig5:	950	03B6	Taiwan (Big5)
+	CsBig5 = CharsetID(950)
+	// CsUnicode:	1200	04B0	Unicode
+	CsUnicode = CharsetID(1200)
+	// CsLatin2:	1250	04E2	Latin-2 (Eastern European)
+	CsLatin2 = CharsetID(1250)
+	// CsCyrillic:	1251	04E3	Cyrillic
+	CsCyrillic = CharsetID(1251)
+	// CsMultilingual:	1252	04E4	Multilingual
+	CsMultilingual = CharsetID(1252)
+	// CsGreek:	1253	04E5	Greek
+	CsGreek = CharsetID(1253)
+	// CsTurkish:	1254	04E6	Turkish
+	CsTurkish = CharsetID(1254)
+	// CsHebrew:	1255	04E7	Hebrew
+	CsHebrew = CharsetID(1255)
+	// CsArabic:	1256	04E8	Arabic
+	CsArabic = CharsetID(1256)
+)
+
+func (cs *CharsetID) UnmarshalJSON(p []byte) error {
+	if p[0] != '"' {
+		return json.Unmarshal(p, cs)
+	}
+	var s string
+	if err := json.Unmarshal(p, &s); err != nil {
+		return err
+	}
+	u, err := strconv.ParseUint(s, 16, 16)
+	if err != nil {
+		return err
+	}
+	*cs = CharsetID(u)
+	return nil
+}
+
+type LangID uint16
+
+func (lng *LangID) UnmarshalJSON(p []byte) error {
+	if p[0] != '"' {
+		return json.Unmarshal(p, lng)
+	}
+	var s string
+	if err := json.Unmarshal(p, &s); err != nil {
+		return err
+	}
+	u, err := strconv.ParseUint(s, 16, 16)
+	if err != nil {
+		return err
+	}
+	*lng = LangID(u)
+	return nil
+}
+
+const (
+	LngArabic                = LangID(0x0401) // LngArabic: 0x0401 Arabic
+	LngBulgarian             = LangID(0x0402) // LngBulgarian: 0x0402 Bulgarian
+	LngCatalan               = LangID(0x0403) // LngCatalan: 0x0403 Catalan
+	LngTraditionalChinese    = LangID(0x0404) // LngTraditionalChinese: 0x0404 Traditional Chinese
+	LngCzech                 = LangID(0x0405) // LngCzech: 0x0405 Czech
+	LngDanish                = LangID(0x0406) // LngDanish: 0x0406 Danish
+	LngGerman                = LangID(0x0407) // LngGerman: 0x0407 German
+	LngGreek                 = LangID(0x0408) // LngGreek: 0x0408 Greek
+	LngUSEnglish             = LangID(0x0409) // LngUSEnglish: 0x0409 U.S. English
+	LngCastilianSpanish      = LangID(0x040A) // LngCastilianSpanish: 0x040A Castilian Spanish
+	LngFinnish               = LangID(0x040B) // LngFinnish: 0x040B Finnish
+	LngFrench                = LangID(0x040C) // LngFrench: 0x040C French
+	LngHebrew                = LangID(0x040D) // LngHebrew: 0x040D Hebrew
+	LngHungarian             = LangID(0x040E) // LngHungarian: 0x040E Hungarian
+	LngIcelandic             = LangID(0x040F) // LngIcelandic: 0x040F Icelandic
+	LngItalian               = LangID(0x0410) // LngItalian: 0x0410 Italian
+	LngJapanese              = LangID(0x0411) // LngJapanese: 0x0411 Japanese
+	LngKorean                = LangID(0x0412) // LngKorean: 0x0412 Korean
+	LngDutch                 = LangID(0x0413) // LngDutch: 0x0413 Dutch
+	LngNorwegianBokmal       = LangID(0x0414) // LngNorwegianBokmal: 0x0414 Norwegian ? Bokmal
+	LngPolish                = LangID(0x0415) // LngPolish: 0x0415 Polish
+	LngPortugueseBrazil      = LangID(0x0416) // LngPortugueseBrazil: 0x0416 Portuguese (Brazil)
+	LngRhaetoRomanic         = LangID(0x0417) // LngRhaetoRomanic: 0x0417 Rhaeto-Romanic
+	LngRomanian              = LangID(0x0418) // LngRomanian: 0x0418 Romanian
+	LngRussian               = LangID(0x0419) // LngRussian: 0x0419 Russian
+	LngCroatoSerbianLatin    = LangID(0x041A) // LngCroatoSerbianLatin: 0x041A Croato-Serbian (Latin)
+	LngSlovak                = LangID(0x041B) // LngSlovak: 0x041B Slovak
+	LngAlbanian              = LangID(0x041C) // LngAlbanian: 0x041C Albanian
+	LngSwedish               = LangID(0x041D) // LngSwedish: 0x041D Swedish
+	LngThai                  = LangID(0x041E) // LngThai: 0x041E Thai
+	LngTurkish               = LangID(0x041F) // LngTurkish: 0x041F Turkish
+	LngUrdu                  = LangID(0x0420) // LngUrdu: 0x0420 Urdu
+	LngBahasa                = LangID(0x0421) // LngBahasa: 0x0421 Bahasa
+	LngSimplifiedChinese     = LangID(0x0804) // LngSimplifiedChinese: 0x0804 Simplified Chinese
+	LngSwissGerman           = LangID(0x0807) // LngSwiss German: 0x0807 Swiss German
+	LngUKEnglish             = LangID(0x0809) // LngUKEnglish: 0x0809 U.K. English
+	LngSpanishMexico         = LangID(0x080A) // LngSpanishMexico: 0x080A Spanish (Mexico)
+	LngBelgianFrench         = LangID(0x080C) // LngBelgian French: 0x080C Belgian French
+	LngSwissItalian          = LangID(0x0810) // LngSwiss Italian: 0x0810 Swiss Italian
+	LngBelgianDutch          = LangID(0x0813) // LngBelgian Dutch: 0x0813 Belgian Dutch
+	LngNorwegianNynorsk      = LangID(0x0814) // LngNorwegianNynorsk: 0x0814 Norwegian ? Nynorsk
+	LngPortuguesePortugal    = LangID(0x0816) // LngPortuguese (Portugal): 0x0816 Portuguese (Portugal)
+	LngSerboCroatianCyrillic = LangID(0x081A) // LngSerboCroatianCyrillic: 0x081A Serbo-Croatian (Cyrillic)
+	LngCanadianFrench        = LangID(0x0C0C) // LngCanadian French: 0x0C0C Canadian French
+	LngSwissFrench           = LangID(0x100C) // LngSwiss French: 0x100C Swiss French
+)

--- a/goversioninfo_test.go
+++ b/goversioninfo_test.go
@@ -362,3 +362,42 @@ func ExampleUseTimestamp() {
 		fmt.Println("Could not load "+file, err)
 	}
 }
+
+func TestStr2Uint32(t *testing.T) {
+	for _, tt := range []struct {
+		in  string
+		out uint32
+	}{{"0", 0}, {"", 0}, {"FFEF", 65519}} {
+		got := str2Uint32(tt.in)
+		if got != tt.out {
+			t.Errorf("%q: awaited %d, got %d.", tt.in, tt.out, got)
+		}
+	}
+}
+func TestLangID(t *testing.T) {
+	var lng LangID
+	for _, tt := range []struct {
+		in      string
+		needErr bool
+	}{{"", false}, {"A", true}, {"1", false}, {`"FfeF"`, false}} {
+		if err := lng.UnmarshalJSON([]byte(tt.in)); tt.needErr && err == nil {
+			t.Errorf("%q: needed error, got nil.", tt.in)
+		} else if !tt.needErr && err != nil {
+			t.Errorf("%q: got error: %v", tt.in, err)
+		}
+	}
+}
+
+func TestCharsetID(t *testing.T) {
+	var cs CharsetID
+	for _, tt := range []struct {
+		in      string
+		needErr bool
+	}{{"", false}, {"A", true}, {"1", false}, {`"FfeF"`, false}} {
+		if err := cs.UnmarshalJSON([]byte(tt.in)); tt.needErr && err == nil {
+			t.Errorf("%q: needed error, got nil.", tt.in)
+		} else if !tt.needErr && err != nil {
+			t.Errorf("%q: got error: %v", tt.in, err)
+		}
+	}
+}

--- a/goversioninfo_test.go
+++ b/goversioninfo_test.go
@@ -8,11 +8,12 @@ package goversioninfo_test
 import (
 	"bytes"
 	"fmt"
-	"github.com/josephspurrier/goversioninfo"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/josephspurrier/goversioninfo"
 )
 
 // *****************************************************************************
@@ -37,25 +38,24 @@ func testFile(t *testing.T, filename string) {
 	vi := &goversioninfo.VersionInfo{}
 
 	// Parse the config
-	if ok := vi.ParseJSON(jsonBytes); ok {
-		// Fill the structures with config data
-		vi.Build()
-
-		// Write the data to a buffer
-		vi.Walk()
-
-		path2, _ := filepath.Abs("./tests/" + filename + ".hex")
-
-		expected, err := ioutil.ReadFile(path2)
-		if err != nil {
-			t.Error("Could not load "+filename+".hex", err)
-		}
-
-		if !bytes.Equal(vi.Buffer.Bytes(), expected) {
-			t.Error("Data does not match " + filename + ".hex")
-		}
-	} else {
+	if err := vi.ParseJSON(jsonBytes); err != nil {
 		t.Error("Could not parse "+filename+".json", err)
+	}
+	// Fill the structures with config data
+	vi.Build()
+
+	// Write the data to a buffer
+	vi.Walk()
+
+	path2, _ := filepath.Abs("./tests/" + filename + ".hex")
+
+	expected, err := ioutil.ReadFile(path2)
+	if err != nil {
+		t.Error("Could not load "+filename+".hex", err)
+	}
+
+	if !bytes.Equal(vi.Buffer.Bytes(), expected) {
+		t.Error("Data does not match " + filename + ".hex")
 	}
 }
 
@@ -73,25 +73,24 @@ func TestWrite(t *testing.T) {
 	vi := &goversioninfo.VersionInfo{}
 
 	// Parse the config
-	if ok := vi.ParseJSON(jsonBytes); ok {
-		// Fill the structures with config data
-		vi.Build()
-
-		// Write the data to a buffer
-		vi.Walk()
-
-		file := "resource.syso"
-
-		vi.WriteSyso(file)
-
-		_, err = ioutil.ReadFile(file)
-		if err != nil {
-			t.Error("Could not load "+file, err)
-		} else {
-			os.Remove(file)
-		}
-	} else {
+	if err := vi.ParseJSON(jsonBytes); err != nil {
 		t.Error("Could not parse "+filename+".json", err)
+	}
+	// Fill the structures with config data
+	vi.Build()
+
+	// Write the data to a buffer
+	vi.Walk()
+
+	file := "resource.syso"
+
+	vi.WriteSyso(file)
+
+	_, err = ioutil.ReadFile(file)
+	if err != nil {
+		t.Error("Could not load "+file, err)
+	} else {
+		os.Remove(file)
 	}
 }
 
@@ -109,8 +108,8 @@ func TestMalformedJSON(t *testing.T) {
 	vi := &goversioninfo.VersionInfo{}
 
 	// Parse the config and return false
-	if ok := vi.ParseJSON(jsonBytes); ok {
-		t.Error("Application was supposed to return false", err)
+	if err := vi.ParseJSON(jsonBytes); err == nil {
+		t.Error("Application was supposed to return error, got nil")
 	}
 }
 
@@ -128,30 +127,29 @@ func TestIcon(t *testing.T) {
 	vi := &goversioninfo.VersionInfo{}
 
 	// Parse the config
-	if ok := vi.ParseJSON(jsonBytes); ok {
-
-		vi.Icon = true
-
-		vi.IconPath = "icon.ico"
-
-		// Fill the structures with config data
-		vi.Build()
-
-		// Write the data to a buffer
-		vi.Walk()
-
-		file := "resource.syso"
-
-		vi.WriteSyso(file)
-
-		_, err = ioutil.ReadFile(file)
-		if err != nil {
-			t.Error("Could not load "+file, err)
-		} else {
-			os.Remove(file)
-		}
-	} else {
+	if err := vi.ParseJSON(jsonBytes); err != nil {
 		t.Error("Could not parse "+filename+".json", err)
+	}
+
+	vi.Icon = true
+
+	vi.IconPath = "icon.ico"
+
+	// Fill the structures with config data
+	vi.Build()
+
+	// Write the data to a buffer
+	vi.Walk()
+
+	file := "resource.syso"
+
+	vi.WriteSyso(file)
+
+	_, err = ioutil.ReadFile(file)
+	if err != nil {
+		t.Error("Could not load "+file, err)
+	} else {
+		os.Remove(file)
 	}
 }
 
@@ -169,29 +167,28 @@ func TestBadIcon(t *testing.T) {
 	vi := &goversioninfo.VersionInfo{}
 
 	// Parse the config
-	if ok := vi.ParseJSON(jsonBytes); ok {
-
-		vi.Icon = true
-		vi.IconPath = "icon2.ico"
-
-		// Fill the structures with config data
-		vi.Build()
-
-		// Write the data to a buffer
-		vi.Walk()
-
-		file := "resource.syso"
-
-		vi.WriteSyso(file)
-
-		_, err = ioutil.ReadFile(file)
-		if err != nil {
-			os.Remove(file)
-		} else {
-			t.Error("File should not exist "+file, err)
-		}
-	} else {
+	if err := vi.ParseJSON(jsonBytes); err != nil {
 		t.Error("Could not parse "+filename+".json", err)
+	}
+
+	vi.Icon = true
+	vi.IconPath = "icon2.ico"
+
+	// Fill the structures with config data
+	vi.Build()
+
+	// Write the data to a buffer
+	vi.Walk()
+
+	file := "resource.syso"
+
+	vi.WriteSyso(file)
+
+	_, err = ioutil.ReadFile(file)
+	if err != nil {
+		os.Remove(file)
+	} else {
+		t.Error("File should not exist "+file, err)
 	}
 }
 
@@ -209,28 +206,27 @@ func TestTimestamp(t *testing.T) {
 	vi := &goversioninfo.VersionInfo{}
 
 	// Parse the config
-	if ok := vi.ParseJSON(jsonBytes); ok {
-
-		vi.Timestamp = true
-
-		// Fill the structures with config data
-		vi.Build()
-
-		// Write the data to a buffer
-		vi.Walk()
-
-		file := "resource.syso"
-
-		vi.WriteSyso(file)
-
-		_, err = ioutil.ReadFile(file)
-		if err != nil {
-			t.Error("Could not load "+file, err)
-		} else {
-			os.Remove(file)
-		}
-	} else {
+	if err := vi.ParseJSON(jsonBytes); err != nil {
 		t.Error("Could not parse "+filename+".json", err)
+	}
+
+	vi.Timestamp = true
+
+	// Fill the structures with config data
+	vi.Build()
+
+	// Write the data to a buffer
+	vi.Walk()
+
+	file := "resource.syso"
+
+	vi.WriteSyso(file)
+
+	_, err = ioutil.ReadFile(file)
+	if err != nil {
+		t.Error("Could not load "+file, err)
+	} else {
+		os.Remove(file)
 	}
 }
 
@@ -248,12 +244,11 @@ func TestVersionString(t *testing.T) {
 	vi := &goversioninfo.VersionInfo{}
 
 	// Parse the config
-	if ok := vi.ParseJSON(jsonBytes); ok {
-		if vi.FixedFileInfo.GetVersionString() != "6.3.9600.16384" {
-			t.Errorf("Version String does not match: %v", vi.FixedFileInfo.GetVersionString())
-		}
-	} else {
+	if err := vi.ParseJSON(jsonBytes); err != nil {
 		t.Error("Could not parse "+filename+".json", err)
+	}
+	if vi.FixedFileInfo.GetVersionString() != "6.3.9600.16384" {
+		t.Errorf("Version String does not match: %v", vi.FixedFileInfo.GetVersionString())
 	}
 }
 
@@ -271,25 +266,24 @@ func TestWriteHex(t *testing.T) {
 	vi := &goversioninfo.VersionInfo{}
 
 	// Parse the config
-	if ok := vi.ParseJSON(jsonBytes); ok {
-		// Fill the structures with config data
-		vi.Build()
-
-		// Write the data to a buffer
-		vi.Walk()
-
-		file := "resource.syso"
-
-		vi.WriteHex(file)
-
-		_, err = ioutil.ReadFile(file)
-		if err != nil {
-			t.Error("Could not load "+file, err)
-		} else {
-			os.Remove(file)
-		}
-	} else {
+	if err := vi.ParseJSON(jsonBytes); err != nil {
 		t.Error("Could not parse "+filename+".json", err)
+	}
+	// Fill the structures with config data
+	vi.Build()
+
+	// Write the data to a buffer
+	vi.Walk()
+
+	file := "resource.syso"
+
+	vi.WriteHex(file)
+
+	_, err = ioutil.ReadFile(file)
+	if err != nil {
+		t.Error("Could not load "+file, err)
+	} else {
+		os.Remove(file)
 	}
 }
 
@@ -311,28 +305,27 @@ func ExampleUseIcon() {
 	vi := &goversioninfo.VersionInfo{}
 
 	// Parse the config
-	if ok := vi.ParseJSON(jsonBytes); ok {
-
-		vi.Icon = true
-
-		vi.IconPath = "icon.ico"
-
-		// Fill the structures with config data
-		vi.Build()
-
-		// Write the data to a buffer
-		vi.Walk()
-
-		file := "resource.syso"
-
-		vi.WriteSyso(file)
-
-		_, err = ioutil.ReadFile(file)
-		if err != nil {
-			fmt.Println("Could not load "+file, err)
-		}
-	} else {
+	if err := vi.ParseJSON(jsonBytes); err != nil {
 		fmt.Println("Could not parse "+filename+".json", err)
+	}
+
+	vi.Icon = true
+
+	vi.IconPath = "icon.ico"
+
+	// Fill the structures with config data
+	vi.Build()
+
+	// Write the data to a buffer
+	vi.Walk()
+
+	file := "resource.syso"
+
+	vi.WriteSyso(file)
+
+	_, err = ioutil.ReadFile(file)
+	if err != nil {
+		fmt.Println("Could not load "+file, err)
 	}
 }
 
@@ -350,26 +343,25 @@ func ExampleUseTimestamp() {
 	vi := &goversioninfo.VersionInfo{}
 
 	// Parse the config
-	if ok := vi.ParseJSON(jsonBytes); ok {
-
-		// Write a timestamp even though it is against the spec
-		vi.Timestamp = true
-
-		// Fill the structures with config data
-		vi.Build()
-
-		// Write the data to a buffer
-		vi.Walk()
-
-		file := "resource.syso"
-
-		vi.WriteSyso(file)
-
-		_, err = ioutil.ReadFile(file)
-		if err != nil {
-			fmt.Println("Could not load "+file, err)
-		}
-	} else {
+	if err := vi.ParseJSON(jsonBytes); err != nil {
 		fmt.Println("Could not parse "+filename+".json", err)
+	}
+
+	// Write a timestamp even though it is against the spec
+	vi.Timestamp = true
+
+	// Fill the structures with config data
+	vi.Build()
+
+	// Write the data to a buffer
+	vi.Walk()
+
+	file := "resource.syso"
+
+	vi.WriteSyso(file)
+
+	_, err = ioutil.ReadFile(file)
+	if err != nil {
+		fmt.Println("Could not load "+file, err)
 	}
 }

--- a/goversioninfo_test.go
+++ b/goversioninfo_test.go
@@ -2,8 +2,7 @@
 // Author: Joseph Spurrier (http://josephspurrier.com)
 // License: http://www.apache.org/licenses/LICENSE-2.0.html
 
-// Package main_test performs testing on main package
-package goversioninfo_test
+package goversioninfo
 
 import (
 	"bytes"
@@ -12,8 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-
-	"github.com/josephspurrier/goversioninfo"
 )
 
 // *****************************************************************************
@@ -35,7 +32,7 @@ func testFile(t *testing.T, filename string) {
 	}
 
 	// Create a new container
-	vi := &goversioninfo.VersionInfo{}
+	vi := &VersionInfo{}
 
 	// Parse the config
 	if err := vi.ParseJSON(jsonBytes); err != nil {
@@ -70,7 +67,7 @@ func TestWrite(t *testing.T) {
 	}
 
 	// Create a new container
-	vi := &goversioninfo.VersionInfo{}
+	vi := &VersionInfo{}
 
 	// Parse the config
 	if err := vi.ParseJSON(jsonBytes); err != nil {
@@ -105,7 +102,7 @@ func TestMalformedJSON(t *testing.T) {
 	}
 
 	// Create a new container
-	vi := &goversioninfo.VersionInfo{}
+	vi := &VersionInfo{}
 
 	// Parse the config and return false
 	if err := vi.ParseJSON(jsonBytes); err == nil {
@@ -124,7 +121,7 @@ func TestIcon(t *testing.T) {
 	}
 
 	// Create a new container
-	vi := &goversioninfo.VersionInfo{}
+	vi := &VersionInfo{}
 
 	// Parse the config
 	if err := vi.ParseJSON(jsonBytes); err != nil {
@@ -164,7 +161,7 @@ func TestBadIcon(t *testing.T) {
 	}
 
 	// Create a new container
-	vi := &goversioninfo.VersionInfo{}
+	vi := &VersionInfo{}
 
 	// Parse the config
 	if err := vi.ParseJSON(jsonBytes); err != nil {
@@ -203,7 +200,7 @@ func TestTimestamp(t *testing.T) {
 	}
 
 	// Create a new container
-	vi := &goversioninfo.VersionInfo{}
+	vi := &VersionInfo{}
 
 	// Parse the config
 	if err := vi.ParseJSON(jsonBytes); err != nil {
@@ -241,7 +238,7 @@ func TestVersionString(t *testing.T) {
 	}
 
 	// Create a new container
-	vi := &goversioninfo.VersionInfo{}
+	vi := &VersionInfo{}
 
 	// Parse the config
 	if err := vi.ParseJSON(jsonBytes); err != nil {
@@ -263,7 +260,7 @@ func TestWriteHex(t *testing.T) {
 	}
 
 	// Create a new container
-	vi := &goversioninfo.VersionInfo{}
+	vi := &VersionInfo{}
 
 	// Parse the config
 	if err := vi.ParseJSON(jsonBytes); err != nil {
@@ -302,7 +299,7 @@ func ExampleUseIcon() {
 	}
 
 	// Create a new container
-	vi := &goversioninfo.VersionInfo{}
+	vi := &VersionInfo{}
 
 	// Parse the config
 	if err := vi.ParseJSON(jsonBytes); err != nil {
@@ -340,7 +337,7 @@ func ExampleUseTimestamp() {
 	}
 
 	// Create a new container
-	vi := &goversioninfo.VersionInfo{}
+	vi := &VersionInfo{}
 
 	// Parse the config
 	if err := vi.ParseJSON(jsonBytes); err != nil {

--- a/icon.go
+++ b/icon.go
@@ -6,12 +6,9 @@ package goversioninfo
 
 import (
 	"encoding/binary"
-	"fmt"
 	"io"
 	"os"
-	"reflect"
 
-	"github.com/akavel/rsrc/binutil"
 	"github.com/akavel/rsrc/coff"
 	"github.com/akavel/rsrc/ico"
 )
@@ -91,40 +88,6 @@ func addIcon(coff *coff.Coff, fname string, newID <-chan uint16) error {
 		}
 		id := <-newID
 		coff.AddResource(rtGroupIcon, id, group)
-	}
-
-	return nil
-}
-
-func writeCoff(coff *coff.Coff, fnameout string) error {
-	out, err := os.Create(fnameout)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		// close error is important
-		if closeErr := out.Close(); closeErr != nil && err == nil {
-			err = closeErr
-		}
-	}()
-	w := binutil.Writer{W: out}
-
-	// write the resulting file to disk
-	binutil.Walk(coff, func(v reflect.Value, path string) error {
-		if binutil.Plain(v.Kind()) {
-			w.WriteLE(v.Interface())
-			return nil
-		}
-		vv, ok := v.Interface().(binutil.SizedReader)
-		if ok {
-			w.WriteFromSized(vv)
-			return binutil.WALK_SKIP
-		}
-		return nil
-	})
-
-	if err = w.Err; err != nil {
-		return fmt.Errorf("Error writing %q file: %v", fnameout, w.Err)
 	}
 
 	return nil

--- a/icon.go
+++ b/icon.go
@@ -1,0 +1,131 @@
+// Copyright 2015 Joseph Spurrier
+// Author: Joseph Spurrier (http://josephspurrier.com)
+// License: http://www.apache.org/licenses/LICENSE-2.0.html
+
+package goversioninfo
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+
+	"github.com/akavel/rsrc/binutil"
+	"github.com/akavel/rsrc/coff"
+	"github.com/akavel/rsrc/ico"
+)
+
+// *****************************************************************************
+/*
+Code from https://github.com/akavel/rsrc
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2014 The rsrc Authors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+// *****************************************************************************
+
+const (
+	rtIcon      = coff.RT_ICON
+	rtGroupIcon = coff.RT_GROUP_ICON
+)
+
+// on storing icons, see: http://blogs.msdn.com/b/oldnewthing/archive/2012/07/20/10331787.aspx
+type gRPICONDIR struct {
+	ico.ICONDIR
+	Entries []gRPICONDIRENTRY
+}
+
+func (group gRPICONDIR) Size() int64 {
+	return int64(binary.Size(group.ICONDIR) + len(group.Entries)*binary.Size(group.Entries[0]))
+}
+
+type gRPICONDIRENTRY struct {
+	ico.IconDirEntryCommon
+	ID uint16
+}
+
+func addIcon(coff *coff.Coff, fname string, newID <-chan uint16) error {
+	f, err := os.Open(fname)
+	if err != nil {
+		return err
+	}
+	//defer f.Close() don't defer, files will be closed by OS when app closes
+
+	icons, err := ico.DecodeHeaders(f)
+	if err != nil {
+		return err
+	}
+
+	if len(icons) > 0 {
+		// RT_ICONs
+		group := gRPICONDIR{ICONDIR: ico.ICONDIR{
+			Reserved: 0, // magic num.
+			Type:     1, // magic num.
+			Count:    uint16(len(icons)),
+		}}
+		for _, icon := range icons {
+			id := <-newID
+			r := io.NewSectionReader(f, int64(icon.ImageOffset), int64(icon.BytesInRes))
+			coff.AddResource(rtIcon, id, r)
+			group.Entries = append(group.Entries, gRPICONDIRENTRY{IconDirEntryCommon: icon.IconDirEntryCommon, ID: id})
+		}
+		id := <-newID
+		coff.AddResource(rtGroupIcon, id, group)
+	}
+
+	return nil
+}
+
+func writeCoff(coff *coff.Coff, fnameout string) error {
+	out, err := os.Create(fnameout)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		// close error is important
+		if closeErr := out.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
+	w := binutil.Writer{W: out}
+
+	// write the resulting file to disk
+	binutil.Walk(coff, func(v reflect.Value, path string) error {
+		if binutil.Plain(v.Kind()) {
+			w.WriteLE(v.Interface())
+			return nil
+		}
+		vv, ok := v.Interface().(binutil.SizedReader)
+		if ok {
+			w.WriteFromSized(vv)
+			return binutil.WALK_SKIP
+		}
+		return nil
+	})
+
+	if err = w.Err; err != nil {
+		return fmt.Errorf("Error writing %q file: %v", fnameout, w.Err)
+	}
+
+	return nil
+}

--- a/lang_cs.go
+++ b/lang_cs.go
@@ -1,0 +1,136 @@
+// Copyright 2015 Tamás Gulácsi
+//
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package goversioninfo
+
+import (
+	"encoding/json"
+	"strconv"
+)
+
+type CharsetID uint16
+
+const (
+	Cs7ASCII       = CharsetID(0)    // Cs7ASCII:	0	0000	7-bit ASCII
+	CsJIS          = CharsetID(932)  // CsJIS:	932	03A4	Japan (Shift ? JIS X-0208)
+	CsKSC          = CharsetID(949)  // CsKSC:	949	03B5	Korea (Shift ? KSC 5601)
+	CsBig5         = CharsetID(950)  // CsBig5:	950	03B6	Taiwan (Big5)
+	CsUnicode      = CharsetID(1200) // CsUnicode:	1200	04B0	Unicode
+	CsLatin2       = CharsetID(1250) // CsLatin2:	1250	04E2	Latin-2 (Eastern European)
+	CsCyrillic     = CharsetID(1251) // CsCyrillic:	1251	04E3	Cyrillic
+	CsMultilingual = CharsetID(1252) // CsMultilingual:	1252	04E4	Multilingual
+	CsGreek        = CharsetID(1253) // CsGreek:	1253	04E5	Greek
+	CsTurkish      = CharsetID(1254) // CsTurkish:	1254	04E6	Turkish
+	CsHebrew       = CharsetID(1255) // CsHebrew:	1255	04E7	Hebrew
+	CsArabic       = CharsetID(1256) // CsArabic:	1256	04E8	Arabic
+)
+
+func (cs *CharsetID) UnmarshalJSON(p []byte) error {
+	if len(p) == 0 {
+		return nil
+	}
+	if p[0] != '"' {
+		var u uint16
+		if err := json.Unmarshal(p, &u); err != nil {
+			return err
+		}
+		*cs = CharsetID(u)
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(p, &s); err != nil {
+		return err
+	}
+	u, err := strconv.ParseUint(s, 16, 16)
+	if err != nil {
+		return err
+	}
+	*cs = CharsetID(u)
+	return nil
+}
+
+type LangID uint16
+
+func (lng *LangID) UnmarshalJSON(p []byte) error {
+	if len(p) == 0 {
+		return nil
+	}
+	if p[0] != '"' {
+		var u uint16
+		if err := json.Unmarshal(p, &u); err != nil {
+			return err
+		}
+		*lng = LangID(u)
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(p, &s); err != nil {
+		return err
+	}
+	u, err := strconv.ParseUint(s, 16, 16)
+	if err != nil {
+		return err
+	}
+	*lng = LangID(u)
+	return nil
+}
+
+const (
+	LngArabic                = LangID(0x0401) // LngArabic: 0x0401 Arabic
+	LngBulgarian             = LangID(0x0402) // LngBulgarian: 0x0402 Bulgarian
+	LngCatalan               = LangID(0x0403) // LngCatalan: 0x0403 Catalan
+	LngTraditionalChinese    = LangID(0x0404) // LngTraditionalChinese: 0x0404 Traditional Chinese
+	LngCzech                 = LangID(0x0405) // LngCzech: 0x0405 Czech
+	LngDanish                = LangID(0x0406) // LngDanish: 0x0406 Danish
+	LngGerman                = LangID(0x0407) // LngGerman: 0x0407 German
+	LngGreek                 = LangID(0x0408) // LngGreek: 0x0408 Greek
+	LngUSEnglish             = LangID(0x0409) // LngUSEnglish: 0x0409 U.S. English
+	LngCastilianSpanish      = LangID(0x040A) // LngCastilianSpanish: 0x040A Castilian Spanish
+	LngFinnish               = LangID(0x040B) // LngFinnish: 0x040B Finnish
+	LngFrench                = LangID(0x040C) // LngFrench: 0x040C French
+	LngHebrew                = LangID(0x040D) // LngHebrew: 0x040D Hebrew
+	LngHungarian             = LangID(0x040E) // LngHungarian: 0x040E Hungarian
+	LngIcelandic             = LangID(0x040F) // LngIcelandic: 0x040F Icelandic
+	LngItalian               = LangID(0x0410) // LngItalian: 0x0410 Italian
+	LngJapanese              = LangID(0x0411) // LngJapanese: 0x0411 Japanese
+	LngKorean                = LangID(0x0412) // LngKorean: 0x0412 Korean
+	LngDutch                 = LangID(0x0413) // LngDutch: 0x0413 Dutch
+	LngNorwegianBokmal       = LangID(0x0414) // LngNorwegianBokmal: 0x0414 Norwegian ? Bokmal
+	LngPolish                = LangID(0x0415) // LngPolish: 0x0415 Polish
+	LngPortugueseBrazil      = LangID(0x0416) // LngPortugueseBrazil: 0x0416 Portuguese (Brazil)
+	LngRhaetoRomanic         = LangID(0x0417) // LngRhaetoRomanic: 0x0417 Rhaeto-Romanic
+	LngRomanian              = LangID(0x0418) // LngRomanian: 0x0418 Romanian
+	LngRussian               = LangID(0x0419) // LngRussian: 0x0419 Russian
+	LngCroatoSerbianLatin    = LangID(0x041A) // LngCroatoSerbianLatin: 0x041A Croato-Serbian (Latin)
+	LngSlovak                = LangID(0x041B) // LngSlovak: 0x041B Slovak
+	LngAlbanian              = LangID(0x041C) // LngAlbanian: 0x041C Albanian
+	LngSwedish               = LangID(0x041D) // LngSwedish: 0x041D Swedish
+	LngThai                  = LangID(0x041E) // LngThai: 0x041E Thai
+	LngTurkish               = LangID(0x041F) // LngTurkish: 0x041F Turkish
+	LngUrdu                  = LangID(0x0420) // LngUrdu: 0x0420 Urdu
+	LngBahasa                = LangID(0x0421) // LngBahasa: 0x0421 Bahasa
+	LngSimplifiedChinese     = LangID(0x0804) // LngSimplifiedChinese: 0x0804 Simplified Chinese
+	LngSwissGerman           = LangID(0x0807) // LngSwiss German: 0x0807 Swiss German
+	LngUKEnglish             = LangID(0x0809) // LngUKEnglish: 0x0809 U.K. English
+	LngSpanishMexico         = LangID(0x080A) // LngSpanishMexico: 0x080A Spanish (Mexico)
+	LngBelgianFrench         = LangID(0x080C) // LngBelgian French: 0x080C Belgian French
+	LngSwissItalian          = LangID(0x0810) // LngSwiss Italian: 0x0810 Swiss Italian
+	LngBelgianDutch          = LangID(0x0813) // LngBelgian Dutch: 0x0813 Belgian Dutch
+	LngNorwegianNynorsk      = LangID(0x0814) // LngNorwegianNynorsk: 0x0814 Norwegian ? Nynorsk
+	LngPortuguesePortugal    = LangID(0x0816) // LngPortuguese (Portugal): 0x0816 Portuguese (Portugal)
+	LngSerboCroatianCyrillic = LangID(0x081A) // LngSerboCroatianCyrillic: 0x081A Serbo-Croatian (Cyrillic)
+	LngCanadianFrench        = LangID(0x0C0C) // LngCanadian French: 0x0C0C Canadian French
+	LngSwissFrench           = LangID(0x100C) // LngSwiss French: 0x100C Swiss French
+)

--- a/structbuild.go
+++ b/structbuild.go
@@ -1,0 +1,309 @@
+// Copyright 2015 Joseph Spurrier
+// Author: Joseph Spurrier (http://josephspurrier.com)
+// License: http://www.apache.org/licenses/LICENSE-2.0.html
+
+package goversioninfo
+
+import (
+	"math"
+	"reflect"
+)
+
+// *****************************************************************************
+// Structure Building
+// *****************************************************************************
+
+/*
+Version Information Structures
+http://msdn.microsoft.com/en-us/library/windows/desktop/ff468916.aspx
+
+VersionInfo Names
+http://msdn.microsoft.com/en-us/library/windows/desktop/aa381058.aspx#string-name
+
+Translation: LangID
+http://msdn.microsoft.com/en-us/library/windows/desktop/aa381058.aspx#langid
+
+Translation: CharsetID
+http://msdn.microsoft.com/en-us/library/windows/desktop/aa381058.aspx#charsetid
+
+*/
+
+// VS_VersionInfo is the top level version container.
+type VS_VersionInfo struct {
+	WLength      uint16
+	WValueLength uint16
+	WType        uint16
+	SzKey        []byte
+	Padding1     []byte
+	Value        VS_FixedFileInfo
+	Padding2     []byte
+	Children     VS_StringFileInfo
+	Children2    VS_VarFileInfo
+}
+
+// VS_FixedFileInfo - most of these should be left at the defaults.
+type VS_FixedFileInfo struct {
+	DwSignature        uint32
+	DwStrucVersion     uint32
+	DwFileVersionMS    uint32
+	DwFileVersionLS    uint32
+	DwProductVersionMS uint32
+	DwProductVersionLS uint32
+	DwFileFlagsMask    uint32
+	DwFileFlags        uint32
+	DwFileOS           uint32
+	DwFileType         uint32
+	DwFileSubtype      uint32
+	DwFileDateMS       uint32
+	DwFileDateLS       uint32
+}
+
+// VS_StringFileInfo holds multiple collections of keys and values,
+// only allows for 1 collection in this package.
+type VS_StringFileInfo struct {
+	WLength      uint16
+	WValueLength uint16
+	WType        uint16
+	SzKey        []byte
+	Padding      []byte
+	Children     VS_StringTable
+}
+
+// VS_StringTable holds a collection of string keys and values.
+type VS_StringTable struct {
+	WLength      uint16
+	WValueLength uint16
+	WType        uint16
+	SzKey        []byte
+	Padding      []byte
+	Children     []VS_String
+}
+
+// VS_String holds the keys and values.
+type VS_String struct {
+	WLength      uint16
+	WValueLength uint16
+	WType        uint16
+	SzKey        []byte
+	Padding1     []byte
+	Value        []byte
+	Padding2     []byte
+}
+
+// VS_VarFileInfo holds the translation collection of 1.
+type VS_VarFileInfo struct {
+	WLength      uint16
+	WValueLength uint16
+	WType        uint16
+	SzKey        []byte
+	Padding      []byte
+	Value        VS_Var
+}
+
+// VS_Var holds the translation key.
+type VS_Var struct {
+	WLength      uint16
+	WValueLength uint16
+	WType        uint16
+	SzKey        []byte
+	Padding      []byte
+	Value        uint32
+}
+
+func buildString(i int, v reflect.Value) (VS_String, bool, uint16) {
+	sValue := string(v.Field(i).Interface().(string))
+	sName := v.Type().Field(i).Name
+
+	ss := VS_String{}
+
+	// If the value is set
+	if sValue != "" {
+		// Create key
+		ss.SzKey = buildUnicode(sName, false)
+		soFar := len(ss.SzKey) + 6
+		ss.Padding1 = padBytes(4 - int(math.Mod(float64(soFar), 4)))
+		// Ensure there is at least 4 bytes between the key and value by NOT
+		// using this code
+		/*if len(ss.Padding1) == 4 {
+			ss.Padding1 = []byte{}
+		}*/
+
+		// Create value
+		ss.Value = buildUnicode(sValue, true)
+		soFar += (len(ss.Value) + len(ss.Padding1))
+		ss.Padding2 = padBytes(4 - int(math.Mod(float64(soFar), 4)))
+		// Eliminate too much spacing
+		if len(ss.Padding2) == 4 {
+			ss.Padding2 = []byte{}
+		}
+
+		// Length of text in words (2 bytes)
+		ss.WValueLength = uint16(len(ss.Value) / 2)
+		// This is NOT a good way because the copyright symbol counts as 2 letters
+		//ss.WValueLength = uint16(len(sValue) + 1)
+
+		// 0 for binary, 1 for text
+		ss.WType = 0x01
+
+		// Length of structure
+		ss.WLength = uint16(soFar)
+		// Don't include the padding in the length, but you must pass it back to
+		// the parent to be included
+		//ss.WLength = uint16(soFar + len(ss.Padding2))
+
+		return ss, true, uint16(len(ss.Padding2))
+	}
+
+	return ss, false, 0
+}
+
+func buildStringTable(vi *VersionInfo) (VS_StringTable, uint16) {
+	st := VS_StringTable{}
+
+	// Always set to 0
+	st.WValueLength = 0x00
+
+	// 0 for binary, 1 for text
+	st.WType = 0x01
+
+	// Language identifier and Code page
+	st.SzKey = buildUnicode(vi.VarFileInfo.Translation.getTranslationString(), false)
+	soFar := len(st.SzKey) + 6
+	st.Padding = padBytes(4 - int(math.Mod(float64(soFar), 4)))
+
+	// Loop through the struct fields
+	v := reflect.ValueOf(vi.StringFileInfo)
+	for i := 0; i < v.NumField(); i++ {
+		// If the struct is valid
+		if r, ok, extra := buildString(i, v); ok {
+			st.Children = append(st.Children, r)
+			st.WLength += (r.WLength + extra)
+		}
+	}
+
+	st.WLength += uint16(soFar)
+
+	return st, uint16(len(st.Padding))
+}
+
+func buildStringFileInfo(vi *VersionInfo) (VS_StringFileInfo, uint16) {
+	sf := VS_StringFileInfo{}
+
+	// Always set to 0
+	sf.WValueLength = 0x00
+
+	// 0 for binary, 1 for text
+	sf.WType = 0x01
+
+	sf.SzKey = buildUnicode("StringFileInfo", false)
+	soFar := len(sf.SzKey) + 6
+	sf.Padding = padBytes(4 - int(math.Mod(float64(soFar), 4)))
+
+	// Allows for more than one string table
+	st, extra := buildStringTable(vi)
+	sf.Children = st
+	sf.WLength += (uint16(soFar) + uint16(len(sf.Padding)) + st.WLength)
+
+	return sf, extra
+}
+
+func buildVar(vfi VarFileInfo) VS_Var {
+	vs := VS_Var{}
+	// Create key
+	vs.SzKey = buildUnicode("Translation", false)
+	soFar := len(vs.SzKey) + 6
+	vs.Padding = padBytes(4 - int(math.Mod(float64(soFar), 4)))
+
+	// Create value
+	vs.Value = str2Uint32(vfi.Translation.getTranslation())
+	soFar += (4 + len(vs.Padding))
+
+	// Length of text in bytes
+	vs.WValueLength = 4
+
+	// 0 for binary, 1 for text
+	vs.WType = 0x00
+
+	// Length of structure
+	vs.WLength = uint16(soFar)
+
+	return vs
+}
+
+func buildVarFileInfo(vfi VarFileInfo) VS_VarFileInfo {
+	vf := VS_VarFileInfo{}
+
+	// Always set to 0
+	vf.WValueLength = 0x00
+
+	// 0 for binary, 1 for text
+	vf.WType = 0x01
+
+	vf.SzKey = buildUnicode("VarFileInfo", false)
+	soFar := len(vf.SzKey) + 6
+	vf.Padding = padBytes(4 - int(math.Mod(float64(soFar), 4)))
+
+	// Allows for more than one string table
+	st := buildVar(vfi)
+	vf.Value = st
+	vf.WLength += (uint16(soFar) + uint16(len(vf.Padding)) + st.WLength)
+
+	return vf
+}
+
+func buildFixedFileInfo(vi *VersionInfo) VS_FixedFileInfo {
+	ff := VS_FixedFileInfo{}
+	ff.DwSignature = 0xFEEF04BD
+	ff.DwStrucVersion = 0x00010000
+	ff.DwFileVersionMS = str2Uint32(vi.FixedFileInfo.FileVersion.getVersionHighString())
+	ff.DwFileVersionLS = str2Uint32(vi.FixedFileInfo.FileVersion.getVersionLowString())
+	ff.DwProductVersionMS = str2Uint32(vi.FixedFileInfo.ProductVersion.getVersionHighString())
+	ff.DwProductVersionLS = str2Uint32(vi.FixedFileInfo.ProductVersion.getVersionLowString())
+	ff.DwFileFlagsMask = str2Uint32(vi.FixedFileInfo.FileFlagsMask)
+	ff.DwFileFlags = str2Uint32(vi.FixedFileInfo.FileFlags)
+	ff.DwFileOS = str2Uint32(vi.FixedFileInfo.FileOS)
+	ff.DwFileType = str2Uint32(vi.FixedFileInfo.FileType)
+	ff.DwFileSubtype = str2Uint32(vi.FixedFileInfo.FileSubType)
+
+	// According to the spec, these should be zero...ugh
+	/*if vi.Timestamp {
+		now := syscall.NsecToFiletime(time.Now().UnixNano())
+		ff.DwFileDateMS = now.HighDateTime
+		ff.DwFileDateLS = now.LowDateTime
+	}*/
+
+	return ff
+}
+
+// Build fills the structs with data from the config file
+func (v *VersionInfo) Build() {
+	vi := VS_VersionInfo{}
+
+	// 0 for binary, 1 for text
+	vi.WType = 0x00
+
+	vi.SzKey = buildUnicode("VS_VERSION_INFO", false)
+	soFar := len(vi.SzKey) + 6
+	vi.Padding1 = padBytes(4 - int(math.Mod(float64(soFar), 4)))
+
+	vi.Value = buildFixedFileInfo(v)
+
+	// Length of value (always the same)
+	vi.WValueLength = 0x34
+
+	// Never needs padding
+	vi.Padding2 = []byte{}
+
+	// Build strings
+	sf, extraPadding := buildStringFileInfo(v)
+	vi.Children = sf
+
+	// Build translation
+	vf := buildVarFileInfo(v.VarFileInfo)
+	vi.Children2 = vf
+
+	// Calculate the total size
+	vi.WLength += (uint16(soFar) + uint16(len(vi.Padding1)) + vi.WValueLength + uint16(len(vi.Padding2)) + vi.Children.WLength + vi.Children2.WLength + extraPadding)
+
+	v.Structure = vi
+}


### PR DESCRIPTION
Hi,

I've just copied your example to a command-line app,
plus made some functions return error, and check that error.

Plus cosmetic changes (go vet + golint), except that goling says we should not use names with underscores  - but that's subjective, and I don't want to be rude.


The remaining big question is how should we fill the versioninfo.json, if not edited by hand?
I've thought the command-line app should get flags for each field in StringFileInfo struct, and overload that.
But I don't know whether this would be enough, or useful at all.

What's your opinion?