### PR TITLE
Added architecture support via command line argument.

### DIFF
--- a/cmd/goversioninfo/main.go
+++ b/cmd/goversioninfo/main.go
@@ -35,6 +35,8 @@ func main() {
 	flagTranslation := flag.Int("translation", 0, "translation ID")
 	flagCharset := flag.Int("charset", 0, "charset ID")
 
+	flag64 := flag.Bool("64", false, "generate 64-bit binaries")
+
 	flagVerMajor := flag.Int("ver-major", -1, "FileVersion.Major")
 	flagVerMinor := flag.Int("ver-minor", -1, "FileVersion.Minor")
 	flagVerPatch := flag.Int("ver-patch", -1, "FileVersion.Patch")
@@ -150,8 +152,14 @@ func main() {
 	// Write the data to a buffer
 	vi.Walk()
 
+	// Set the architecture, defaulted to 32-bit.
+	arch := "386" // 32-bit
+	if flag64 != nil && *flag64 {
+		arch = "amd64" // 64-bit
+	}
+
 	// Create the file
-	if err := vi.WriteSyso(*flagOut); err != nil {
+	if err := vi.WriteSyso(*flagOut, arch); err != nil {
 		log.Printf("Error writing syso: %v", err)
 		os.Exit(3)
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -40,7 +40,7 @@ func logic() {
 	vi.IconPath = "icon.ico"
 
 	// Create the file
-	if err := vi.WriteSyso("resource.syso"); err != nil {
+	if err := vi.WriteSyso("resource.syso", "386"); err != nil {
 		log.Printf("Error writing syso: %v", err)
 		os.Exit(3)
 	}

--- a/goversioninfo.go
+++ b/goversioninfo.go
@@ -170,8 +170,9 @@ func (vi *VersionInfo) Walk() {
 	vi.Buffer = b
 }
 
-// WriteSyso creates a resource file from the version info and optionally an icon
-func (vi *VersionInfo) WriteSyso(filename string) error {
+// WriteSyso creates a resource file from the version info and optionally an icon.
+// arch must be an architecture string accepted by coff.Arch, like "386" or "amd64"
+func (vi *VersionInfo) WriteSyso(filename string, arch string) error {
 
 	// Channel for generating IDs
 	newID := make(chan uint16)
@@ -183,6 +184,12 @@ func (vi *VersionInfo) WriteSyso(filename string) error {
 
 	// Create a new RSRC section
 	coff := coff.NewRSRC()
+
+	// Set the architechture
+	err := coff.Arch(arch)
+	if err != nil {
+		return err
+	}
 
 	// ID 16 is for Version Information
 	coff.AddResource(16, 1, SizedReader{&vi.Buffer})

--- a/goversioninfo_test.go
+++ b/goversioninfo_test.go
@@ -61,7 +61,15 @@ func testFile(t *testing.T, filename string) {
 	}
 }
 
-func TestWrite(t *testing.T) {
+func TestWrite32(t *testing.T) {
+	doTestWrite(t, "386")
+}
+
+func TestWrite64(t *testing.T) {
+	doTestWrite(t, "amd64")
+}
+
+func doTestWrite(t *testing.T, arch string) {
 	filename := "cmd"
 
 	path, _ := filepath.Abs("./tests/" + filename + ".json")
@@ -86,7 +94,7 @@ func TestWrite(t *testing.T) {
 
 	file := "resource.syso"
 
-	vi.WriteSyso(file)
+	vi.WriteSyso(file, arch)
 
 	_, err = ioutil.ReadFile(file)
 	if err != nil {
@@ -143,7 +151,7 @@ func TestIcon(t *testing.T) {
 
 	file := "resource.syso"
 
-	vi.WriteSyso(file)
+	vi.WriteSyso(file, "386")
 
 	_, err = ioutil.ReadFile(file)
 	if err != nil {
@@ -181,7 +189,7 @@ func TestBadIcon(t *testing.T) {
 
 	file := "resource.syso"
 
-	vi.WriteSyso(file)
+	vi.WriteSyso(file, "386")
 
 	_, err = ioutil.ReadFile(file)
 	if err != nil {
@@ -219,7 +227,7 @@ func TestTimestamp(t *testing.T) {
 
 	file := "resource.syso"
 
-	vi.WriteSyso(file)
+	vi.WriteSyso(file, "386")
 
 	_, err = ioutil.ReadFile(file)
 	if err != nil {
@@ -318,7 +326,7 @@ func ExampleUseIcon() {
 
 	file := "resource.syso"
 
-	vi.WriteSyso(file)
+	vi.WriteSyso(file, "386")
 
 	_, err = ioutil.ReadFile(file)
 	if err != nil {
@@ -355,7 +363,7 @@ func ExampleUseTimestamp() {
 
 	file := "resource.syso"
 
-	vi.WriteSyso(file)
+	vi.WriteSyso(file, "386")
 
 	_, err = ioutil.ReadFile(file)
 	if err != nil {


### PR DESCRIPTION
In order to link against 32- or 64-bit binaries, the .syso file must
match the binaries against which it links. The coff library supports
multiple archs, so this extends that support here.

This closes issue #5.