### PR TITLE
Fix empty resources when platform-specific=true.

### DIFF
--- a/goversioninfo.go
+++ b/goversioninfo.go
@@ -197,7 +197,7 @@ func (vi *VersionInfo) WriteSyso(filename string, arch string) error {
 	}
 
 	// ID 16 is for Version Information
-	coff.AddResource(16, 1, SizedReader{&vi.Buffer})
+	coff.AddResource(16, 1, SizedReader{bytes.NewBuffer(vi.Buffer.Bytes())})
 
 	// If manifest is enabled
 	if vi.ManifestPath != "" {


### PR DESCRIPTION
Same byte.Buffer can not be used for multiple AddResource calls because buffer can only be read once. When **platform-specific=true** is specified, only **resource_windows_386.syso** file contains specified resources and **resource_windows_amd64.syso** does not contain version resource in it.