### PR TITLE
Generate RT_GROUP_ICON id before ICON ids

### DIFF
--- a/icon.go
+++ b/icon.go
@@ -77,14 +77,14 @@ func addIcon(coff *coff.Coff, fname string, newID <-chan uint16) error {
 			Type:     1, // magic num.
 			Count:    uint16(len(icons)),
 		}}
+		gid := <-newID
 		for _, icon := range icons {
 			id := <-newID
 			r := io.NewSectionReader(f, int64(icon.ImageOffset), int64(icon.BytesInRes))
 			coff.AddResource(rtIcon, id, r)
 			group.Entries = append(group.Entries, gRPICONDIRENTRY{IconDirEntryCommon: icon.IconDirEntryCommon, ID: id})
 		}
-		id := <-newID
-		coff.AddResource(rtGroupIcon, id, group)
+		coff.AddResource(rtGroupIcon, gid, group)
 	}
 
 	return nil


### PR DESCRIPTION
This ensures the group icon always has a consistent ID that can be used by the application to find the icon, even when the ico file itself contains a different number of resolution variations.

This is the same as https://github.com/akavel/rsrc/pull/18, because for some reason this code is duplicated in both libraries.