### PR TITLE
Fix the example manifest #19

### DIFF
--- a/goversioninfo.exe.manifest
+++ b/goversioninfo.exe.manifest
@@ -1,15 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
- <dependency>
-   <dependentAssembly>
-     <assemblyIdentity
-       type="win32"
-       name="Github.com.JosephSpurrier.GoVersionInfo"
-       version="1.0.0.0"
-       language="*"
-       processorArchitecture="*"/>
-   </dependentAssembly>
- </dependency>
+  <assemblyIdentity
+    type="win32"
+    name="Github.com.JosephSpurrier.GoVersionInfo"
+    version="1.0.0.0"
+    language="*"
+    processorArchitecture="*"/>
  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
    <security>
      <requestedPrivileges>


### PR DESCRIPTION
Pull the tag "assemblyIdentity" up to level to be directly under "assembly". This fixes the "side by side configuration is incorrect" error when using this example in a project.
It's the first time I'm using a manifest. Therefore I might overlook why the manifest is as it is. But from what I understand there is no need to declare a dependency. Instead we want to declare the parameter like version for the current project.

With this change the manifest can just be copied and used right away.