### PR TITLE
Buffer data instead of holding file reference

### DIFF
--- a/icon.go
+++ b/icon.go
@@ -1,6 +1,7 @@
 package goversioninfo
 
 import (
+	"bytes"
 	"encoding/binary"
 	"io"
 	"os"
@@ -63,7 +64,7 @@ func addIcon(coff *coff.Coff, fname string, newID <-chan uint16) error {
 	if err != nil {
 		return err
 	}
-	//defer f.Close() don't defer, files will be closed by OS when app closes
+	defer f.Close()
 
 	icons, err := ico.DecodeHeaders(f)
 	if err != nil {
@@ -81,11 +82,25 @@ func addIcon(coff *coff.Coff, fname string, newID <-chan uint16) error {
 		for _, icon := range icons {
 			id := <-newID
 			r := io.NewSectionReader(f, int64(icon.ImageOffset), int64(icon.BytesInRes))
-			coff.AddResource(rtIcon, id, r)
+			buffered, err := bufferIcon(r)
+			if err != nil {
+				return err
+			}
+			coff.AddResource(rtIcon, id, buffered)
 			group.Entries = append(group.Entries, gRPICONDIRENTRY{IconDirEntryCommon: icon.IconDirEntryCommon, ID: id})
 		}
 		coff.AddResource(rtGroupIcon, gid, group)
 	}
 
 	return nil
+}
+
+func bufferIcon(read *io.SectionReader) (*io.SectionReader, error) {
+	size := read.Size()
+	data := make([]byte, size)
+	_, err := io.ReadFull(read, data)
+	if err != nil {
+		return nil, err
+	}
+	return io.NewSectionReader(bytes.NewReader(data), 0, size), nil
 }

--- a/icon_test.go
+++ b/icon_test.go
@@ -1,0 +1,33 @@
+package goversioninfo
+
+import (
+	"log"
+	"os"
+	"runtime"
+	"testing"
+)
+
+func TestTempIcon(t *testing.T) {
+	icoPath := "tmp.ico"
+	outPath := "resource.syso"
+	vi := &VersionInfo{}
+	vi.IconPath = icoPath
+
+	f, _ := os.Create(icoPath)
+	err := f.Close()
+	if err != nil {
+		log.Println("Unexpected error closing new file")
+	}
+
+	vi.Build()
+	vi.Walk()
+	err = vi.WriteSyso(outPath, runtime.GOARCH)
+	if err != nil {
+		log.Println("Unexpected error writing resource")
+	}
+
+	err = os.Remove(icoPath)
+	if err != nil {
+		t.Fatal("Error deleting temporary icon", err)
+	}
+}


### PR DESCRIPTION
The file handle was being retained by the io.SectionReader.
If we cache this data the file can be released and Close()d.

Fixes #30