### PR TITLE
Do not put language attribute in manifest, the compiled program could not start

### DIFF
--- a/testdata/resource/goversioninfo.exe.manifest
+++ b/testdata/resource/goversioninfo.exe.manifest
@@ -4,7 +4,6 @@
     type="win32"
     name="Github.com.JosephSpurrier.GoVersionInfo"
     version="1.0.0.0"
-    language="*"
     processorArchitecture="*"/>
  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
    <security>


### PR DESCRIPTION
Do not put language attribute in manifest, the compiled program could not start