### PR TITLE
Add an option to parse string versions into FixedFileInfo

### DIFF
--- a/cmd/goversioninfo/main.go
+++ b/cmd/goversioninfo/main.go
@@ -22,6 +22,8 @@ func main() {
 	flagIcon := flag.String("icon", "", "icon file name")
 	flagManifest := flag.String("manifest", "", "manifest file name")
 	flagSkipVersion := flag.Bool("skip-versioninfo", false, "skip version info")
+	flagPropagateVerStrings := flag.Bool("propagate-ver-strings", false,
+		"fill FixedFileInfo version fields using FileVersion and ProductVersion from the StringFileInfo")
 
 	flagComment := flag.String("comment", "", "StringFileInfo.Comments")
 	flagCompany := flag.String("company", "", "StringFileInfo.CompanyName")
@@ -173,6 +175,24 @@ func main() {
 	}
 	if *flagProductVerBuild >= 0 {
 		vi.FixedFileInfo.ProductVersion.Build = *flagProductVerBuild
+	}
+
+	// Fill FixedFileInfo versions if needed.
+	if *flagPropagateVerStrings && vi.StringFileInfo.FileVersion != "" {
+		v, err := goversioninfo.NewFileVersion(vi.StringFileInfo.FileVersion)
+		if err != nil {
+			log.Printf("Unexpected StringFileInfo.FileVersion format: %v", err)
+			os.Exit(3)
+		}
+		vi.FixedFileInfo.FileVersion = v
+	}
+	if *flagPropagateVerStrings && vi.StringFileInfo.ProductVersion != "" {
+		v, err := goversioninfo.NewFileVersion(vi.StringFileInfo.ProductVersion)
+		if err != nil {
+			log.Printf("Unexpected StringFileInfo.ProductVersion format: %v", err)
+			os.Exit(3)
+		}
+		vi.FixedFileInfo.ProductVersion = v
 	}
 
 	// Fill the structures with config data.

--- a/goversioninfo_test.go
+++ b/goversioninfo_test.go
@@ -381,6 +381,42 @@ func TestWriteCoff(t *testing.T) {
 	}
 }
 
+func TestNewFileVersion(t *testing.T) {
+	cases := []struct {
+		in  string
+		out FileVersion
+		err string
+	}{
+		// Correct.
+		{"1.2.3", FileVersion{1, 2, 3, 0}, ""},
+		{"1.2.3.a", FileVersion{1, 2, 3, 0}, ""},
+		{"1.2.3.4", FileVersion{1, 2, 3, 4}, ""},
+		{"1.2.3.4-RC.1", FileVersion{1, 2, 3, 4}, ""},
+		{"1.2.3.4 (final)", FileVersion{1, 2, 3, 4}, ""},
+		{"6.3.9600.17284 (aaa.140822-1915)", FileVersion{6, 3, 9600, 17284}, ""},
+
+		// Unexpected format.
+		{"1.2", FileVersion{}, "version expected to start from x.y.z"},
+		{"1.3.a", FileVersion{}, "version expected to start from x.y.z"},
+		{"v1.2.3", FileVersion{}, "version expected to start from x.y.z"},
+
+		// Any way to check Atoi errors except of overflow?
+		{"1.1.1.9223372036854775808", FileVersion{}, "9223372036854775808"},
+	}
+	for i, c := range cases {
+		got, err := NewFileVersion(c.in)
+		if err == nil && c.err == "" && got != c.out {
+			t.Errorf("%d) %q: expected %+v got %+v", i, c.in, c.out, got)
+		} else if err == nil && c.err != "" {
+			t.Errorf("%d) %q: expected error with susbtring %q got nil", i, c.in, c.err)
+		} else if err != nil && c.err == "" {
+			t.Errorf("%d) %q: unexpected error %s", i, c.in, err)
+		} else if err != nil && c.err != "" && !strings.Contains(err.Error(), c.err) {
+			t.Errorf("%d) %q: expected error with susbtring %q got %s", i, c.in, c.err, err)
+		}
+	}
+}
+
 type badWriter struct {
 	writeErr, closeErr error
 }


### PR DESCRIPTION
During our release pipeline we always need to update all version components of the `versioninfo.json`, which is a bit tedious as we not only have to update version strings, but also split the strings an a number components to fill the `FixedFileInfo` structs

We used to use a small utility to parse and insert new version in to the JSON file, but it seems as a common problem for most of `goversioninfo` users (at least for those, who want to add a version into the binary)

Here we propose a new CLI option which will use "string versions" set in  `StringFileInfo` (or using `--file-version` and `--product-version` flags) to fill the corresponding structs in the `FixedFileInfo`