### PR TITLE
Enable specifying multiple icon file names separated by commas

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Complete list of the flags for goversioninfo:
   -description="": StringFileInfo.FileDescription
   -example=false: dump out an example versioninfo.json to stdout
   -file-version="": StringFileInfo.FileVersion
-  -icon="": icon file name
+  -icon="": icon file name(s), separated by commas
   -internal-name="": StringFileInfo.InternalName
   -manifest="": manifest file name
   -skip-versioninfo=false: skip version info reading on true, allows setting just icon

--- a/cmd/goversioninfo/main.go
+++ b/cmd/goversioninfo/main.go
@@ -19,7 +19,7 @@ func main() {
 	flagGo := flag.String("gofile", "", "Go output file name (optional)")
 	flagPackage := flag.String("gofilepackage", "main", "Go output package name (optional, requires parameter: 'gofile')")
 	flagPlatformSpecific := flag.Bool("platform-specific", false, "output i386, amd64, arm and arm64 named resource.syso, ignores -o")
-	flagIcon := flag.String("icon", "", "icon file name")
+	flagIcon := flag.String("icon", "", "icon file name(s), separated by commas")
 	flagManifest := flag.String("manifest", "", "manifest file name")
 	flagSkipVersion := flag.Bool("skip-versioninfo", false, "skip version info")
 

--- a/icon.go
+++ b/icon.go
@@ -3,7 +3,9 @@ package goversioninfo
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"os"
+	"strings"
 
 	"github.com/akavel/rsrc/coff"
 	"github.com/akavel/rsrc/ico"
@@ -58,7 +60,23 @@ type gRPICONDIRENTRY struct {
 	ID uint16
 }
 
-func addIcon(coff *coff.Coff, fname string, newID func() uint16) error {
+func addIcon(coff *coff.Coff, fnames string, newID func() uint16) error {
+	for {
+		var fname1 string
+		var ok bool
+		fname1, fnames, ok = strings.Cut(fnames, ",")
+		if fname1 != "" {
+			if err := addOneIcon(coff, fname1, newID); err != nil {
+				return fmt.Errorf("%s: %w", fname1, err)
+			}
+		}
+		if !ok {
+			return nil
+		}
+	}
+}
+
+func addOneIcon(coff *coff.Coff, fname string, newID func() uint16) error {
 	f, err := os.Open(fname)
 	if err != nil {
 		return err


### PR DESCRIPTION
If an executable includes multiple icons, users can choose which one to use when creating a shortcut. This can be helpful when they need to distinguish between multiple versions of the same application.

The current goversioninfo appears to support only a single icon file. I have modified it to allow specifying multiple icon file names separated by commas.

If there are no issues, I would appreciate it if you could merge my patch.

### Example :

```
goversioninfo -icon=nyagos.ico,nyagos32x32.ico,nyagos16x16.ico -o nyagos.syso v.json
```

The resulting executable will include multiple icons, allowing users to choose one when creating a shortcut.

![image](https://github.com/user-attachments/assets/62d7122f-70c2-447b-bada-ea271c0aa53a)